### PR TITLE
fix(deps): pin cartesia Python SDK to v2 (compat with MCP server)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "cartesia>=2.0.2",
+    # SDK v3 moved modules (e.g. cartesia.core); server still targets v2 APIs — pin until migrated.
+    "cartesia>=2.0.2,<3.0.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.7.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -133,7 +133,7 @@ version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "audioop-lts", marker = "python_full_version < '4.0'" },
+    { name = "audioop-lts", marker = "python_full_version < '4'" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "iterators" },
@@ -150,8 +150,8 @@ wheels = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.1.0"
-source = { virtual = "." }
+version = "0.1.6"
+source = { editable = "." }
 dependencies = [
     { name = "cartesia" },
     { name = "httpx" },
@@ -160,7 +160,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", specifier = ">=2.0.2" },
+    { name = "cartesia", specifier = ">=2.0.2,<3.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.7.1" },
 ]


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-664/cartesia-mcp-default-install-broken-pin-or-migrate-for-cartesia-python

## Summary

`pip install cartesia-mcp` was resolving **cartesia** Python SDK v3 while `cartesia_mcp/server.py` still imports **v2** paths (`cartesia.core.pagination`, etc.), causing `ModuleNotFoundError` at import. This pins **cartesia>=2.0.2,<3.0.0** until the MCP server is migrated to the v3 SDK surface.

## Changes

- `pyproject.toml`: add upper bound `<3.0.0` with a short comment.
- Regenerate `uv.lock` so installs resolve to SDK v2.

## Verification

- `uv sync` and `CARTESIA_API_KEY=test uv run python -c "from cartesia_mcp.server import mcp"` succeeds.
- MCP stdio `initialize` returns a normal JSON-RPC result (see smoke scripts under workspace `demos/mcp`).