### PR TITLE
release: cartesia-mcp 0.1.7

### DIFF
--- a/cartesia_mcp/__init__.py
+++ b/cartesia_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Cartesia MCP Server package."""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cartesia-mcp"
-version = "0.1.6"
+version = "0.1.7"
 description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia" },


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-799/publish-cartesia-mcp

## Summary

Bumps `cartesia-mcp` to **0.1.7** so we can publish to PyPI with the cartesia SDK v2 pin and the README updates already merged to `main`. PyPI 0.1.6 still allows `cartesia>=3`, which breaks the server until we migrate to the v3 API.

## Changes

- Bump version to `0.1.7` in `pyproject.toml` and `cartesia_mcp/__init__.py`
- Refresh `uv.lock`

## Publish steps (after merge)

```sh
git checkout main && git pull
uv build
uv publish   # requires PyPI token for cartesia-mcp
```


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile edits only; no application logic changes in this diff.
> 
> **Overview**
> Bumps **cartesia-mcp** from `0.1.6` to **`0.1.7`** in `pyproject.toml`, `cartesia_mcp/__init__.py`, and the `cartesia-mcp` entry in `uv.lock`.
> 
> This is a **release-only** change: no server or dependency logic is modified in the diff. The intent is to publish a new PyPI artifact so installs pick up the **`cartesia>=2.0.2,<3.0.0`** pin and related fixes already on `main`, avoiding broken installs that pull **cartesia v3** against the current server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d9fc27d355e97f25cc6c59d6b155719d04051a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->