### PR TITLE
ci: chain PyPI publish after release-please

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,13 +1,11 @@
 # Publishes to PyPI using a project-scoped API token stored as a GitHub secret.
 # Add PYPI_API_TOKEN under Settings → Secrets and variables → Actions.
 #
-# Triggered when a GitHub release is published (e.g. by release-please).
-# Can also be run manually to re-publish if a prior run failed.
+# Normally publish runs as a job in release-please.yml after a release is created.
+# workflow_dispatch is kept for manual re-publishes if a prior run failed.
 name: Publish PyPI
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,9 @@
 # Opens and updates release PRs from conventional commits on main.
-# When the release PR merges, release-please creates a GitHub release,
-# which triggers publish-pypi.yml.
+# When the release PR merges, release-please creates a GitHub release and
+# the publish job ships to PyPI.
+#
+# Note: releases created with GITHUB_TOKEN do not fire release:published, so
+# publish runs as a chained job here instead of a separate workflow trigger.
 name: Release Please
 
 on:
@@ -15,7 +18,34 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: actions/checkout@v6
+
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish


### PR DESCRIPTION
## Summary

Fixes auto-publish for future releases. GitHub suppresses `release:published` events when the release is created by `GITHUB_TOKEN` (which release-please uses).

## Changes

- Add `publish` job to `release-please.yml` that runs when `release_created == true`
- Keep `publish-pypi.yml` as manual `workflow_dispatch` only (for re-publishes)

## Test plan

- [x] 0.1.8 published manually via workflow_dispatch
- [ ] Next release PR merge should auto-publish without manual trigger

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release automation only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> **PyPI publishing is chained onto the release-please workflow** so releases created with `GITHUB_TOKEN` still ship automatically—GitHub does not emit `release:published` for those releases, which broke the old separate-workflow trigger.
> 
> The **`release-please` job** now checks out the repo, exposes `release_created` and `tag_name` as job outputs, and a new **`publish` job** runs only when a release was created: it checks out the release tag, builds with `uv build`, and publishes with `UV_PUBLISH_TOKEN`.
> 
> **`publish-pypi.yml`** no longer runs on `release:published`; it is **manual `workflow_dispatch` only** for re-publishes if an automated run fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920cf059f8d7d32ef4ee6d9ce9bdb5875c1452da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->