### PR TITLE
docs(readme): remove redundant Python version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Cartesia MCP Server
 
 [![PyPI version](https://img.shields.io/pypi/v/cartesia-mcp)](https://pypi.org/project/cartesia-mcp/)
-[![Python](https://img.shields.io/pypi/pyversions/cartesia-mcp)](https://pypi.org/project/cartesia-mcp/)
 
 The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) so clients such as **Cursor**, **Claude Desktop**, and **OpenAI Agents** can list voices, run **TTS**, clone voices, infill audio, and more—without one-off scripts.
 


### PR DESCRIPTION
## Summary

Removes the Python version badge from the README; the PyPI badge and Requirements section already cover this.

Triggers patch release 0.1.10.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only badge removal with no runtime or API impact.
> 
> **Overview**
> Removes the redundant **Python version** shields.io badge from the README header, leaving only the PyPI version badge. Python support is still documented in **Requirements** (`Python 3.13+` and `pyproject.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c199f7039bc9fb45635773ca093f889628f8abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->