### PR TITLE
docs(readme): simplify setup to uv-only quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,64 +4,21 @@
 
 The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) so clients such as **Cursor**, **Claude Desktop**, and **OpenAI Agents** can list voices, run **TTS**, clone voices, infill audio, and more—without one-off scripts.
 
-**Documentation:** [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp) (overview and links back to this README).
+**Documentation:** [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp)
 
 ## Requirements
 
-- **Python 3.13+** (required; enforced in [`pyproject.toml`](./pyproject.toml))
-- A **[Cartesia API key](https://play.cartesia.ai/keys)** — create one under **API Keys** after signing in at the [playground](https://play.cartesia.ai/sign-in). Free tier includes 20,000 credits per month.
+- **[uv](https://docs.astral.sh/uv/)** — runs the server via `uvx` with no global install
+- **Python 3.13+** (installed automatically by `uvx`)
+- A **[Cartesia API key](https://play.cartesia.ai/keys)**
 
-## Installation
+## Setup
 
-### pip
+Add this to your MCP config. You only need your API key.
 
-```sh
-pip install cartesia-mcp
-which cartesia-mcp   # copy absolute path for MCP config below
-```
+**Cursor** — `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` globally.
 
-### uv (recommended for ephemeral runs)
-
-If you use [uv](https://docs.astral.sh/uv/), you can run the published package without a global install:
-
-```sh
-uvx cartesia-mcp
-```
-
-Use `which uvx` or `command -v uvx` if your MCP client needs an absolute path to `uvx`. Some clients invoke MCP via `command` + `args` (see [Cursor](#cursor-integration)).
-
-## Environment
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `CARTESIA_API_KEY` | Yes | Your Cartesia API key |
-| `OUTPUT_DIRECTORY` | No | Directory for generated audio files (defaults to `.`) |
-
-## Claude Desktop integration
-
-Edit **Settings → Developer → Edit Config** (`claude_desktop_config.json`).
-
-Use either the **installed executable** (from `pip install`) or **`uvx`**:
-
-### Installed `cartesia-mcp`
-
-```json
-{
-  "mcpServers": {
-    "cartesia-mcp": {
-      "command": "/absolute/path/to/cartesia-mcp",
-      "env": {
-        "CARTESIA_API_KEY": "<your-api-key>",
-        "OUTPUT_DIRECTORY": "/absolute/path/to/output"
-      }
-    }
-  }
-}
-```
-
-Omit `OUTPUT_DIRECTORY` to write files to the process working directory.
-
-### uvx
+**Claude Desktop** — **Settings → Developer → Edit Config** (`claude_desktop_config.json`).
 
 ```json
 {
@@ -77,49 +34,17 @@ Omit `OUTPUT_DIRECTORY` to write files to the process working directory.
 }
 ```
 
-### Try asking Claude to…
+Restart the client (or refresh MCP in Cursor) and confirm **cartesia-mcp** is connected.
+
+## Try it
+
+Ask your agent things like:
 
 - List all available Cartesia voices
 - Convert text to audio with a chosen voice
 - Localize an existing voice into another language
-- Infill audio between two segments (provide absolute paths to audio files)
+- Infill audio between two existing audio segments
 - Change an audio file to use a different voice
-
-## Cursor integration
-
-Create **`.cursor/mcp.json`** in your project or **`~/.cursor/mcp.json`** globally.
-
-### Installed `cartesia-mcp`
-
-```json
-{
-  "mcpServers": {
-    "cartesia-mcp": {
-      "command": "/absolute/path/to/cartesia-mcp",
-      "env": {
-        "CARTESIA_API_KEY": "<your-api-key>",
-        "OUTPUT_DIRECTORY": "/absolute/path/to/output"
-      }
-    }
-  }
-}
-```
-
-### uvx
-
-```json
-{
-  "mcpServers": {
-    "cartesia-mcp": {
-      "command": "uvx",
-      "args": ["cartesia-mcp"],
-      "env": {
-        "CARTESIA_API_KEY": "<your-api-key>"
-      }
-    }
-  }
-}
-```
 
 ## Tools
 
@@ -136,3 +61,20 @@ Create **`.cursor/mcp.json`** in your project or **`~/.cursor/mcp.json`** global
 | `localize_voice` | Adapt a voice to another language or dialect |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.
+
+## Advanced
+
+### Output directory
+
+By default, generated audio is written to the server's working directory. To choose a fixed folder, add `OUTPUT_DIRECTORY` to `env`:
+
+```json
+"env": {
+  "CARTESIA_API_KEY": "<your-api-key>",
+  "OUTPUT_DIRECTORY": "~/cartesia-output"
+}
+```
+
+### Local audio files
+
+Tools like `infill` and `voice_change` need paths to existing audio files on disk. Pass the full path to each file when prompting your agent.


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-799/publish-cartesia-mcp

## Summary

Streamlines the README so new users can follow one path: install via `uvx`, paste one MCP config, and go.

## Changes

- uv-only setup — remove pip install and absolute-path examples
- Single shared MCP config for Cursor and Claude Desktop
- Minimal first example with only `CARTESIA_API_KEY`
- Move `OUTPUT_DIRECTORY` and local file path notes to Advanced
- Remove free-tier credits note

Should trigger release-please for 0.1.11 after merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> The README is reworked around a **single uvx-based quick start**: requirements now lead with **uv** and note Python 3.13 is pulled in by `uvx`, and the old **pip install**, **absolute-path `cartesia-mcp` binary**, and duplicate per-client config blocks are removed.
> 
> **Setup** is one shared JSON snippet (only `CARTESIA_API_KEY`) for both Cursor and Claude Desktop, with short pointers to each config file and a step to verify the server is connected. **Environment** and separate integration sections are folded into that flow.
> 
> **Advanced** now holds optional `OUTPUT_DIRECTORY` and guidance on local file paths for `infill` / `voice_change`. Minor copy edits (docs link, try-it bullets) and removal of the free-tier credits note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7567ed28bc2604e5b11b1ccc9f4d998962eba4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->