### PR TITLE
Fix MCP tool return types and voice CRUD handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wheels/
 
 # Mac 
 .DS_Store
+
+# Local MCP smoke-test output
+test-output/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Ask your agent things like:
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.
 
+## Testing
+
+Smoke-test all tools (requires `CARTESIA_API_KEY`):
+
+```sh
+uv run python scripts/test_all_tools.py
+```
+
+The script creates temporary cloned/localized voices and deletes only those. It does not delete catalog or other existing voices.
+
 ## Advanced
 
 ### Output directory

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -76,7 +76,7 @@ def text_to_speech(
     with output_file.open("wb") as f:
         f.write(audio_bytes)
 
-        return GeneratedAudioResult(file_path=output_file)
+    return GeneratedAudioResult(file_path=str(output_file))
 
 @mcp.tool(description="""
         Generate audio that smoothly connects two existing audio segments. This is useful for inserting new speech between existing speech segments while maintaining natural transitions.
@@ -162,7 +162,7 @@ def infill(
     with output_file.open("wb") as f:
         f.write(audio_bytes)
 
-    return GeneratedAudioResult(file_path=output_file)
+    return GeneratedAudioResult(file_path=str(output_file))
 
 
 @mcp.tool(description="""
@@ -198,23 +198,24 @@ def voice_change(
     output_format_bit_rate: typing.Optional[int] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> GeneratedAudioResult:
-    result = client.voice_changer.bytes(
-        clip=open(file_path, "rb"),
-        voice_id=voice_id,
-        output_format_container=output_format_container,
-        output_format_sample_rate=output_format_sample_rate,
-        output_format_encoding=output_format_encoding,
-        output_format_bit_rate=output_format_bit_rate,
-        request_options=request_options)
+    with open(file_path, "rb") as clip:
+        result = client.voice_changer.bytes(
+            clip=clip,
+            voice_id=voice_id,
+            output_format_container=output_format_container,
+            output_format_sample_rate=output_format_sample_rate,
+            output_format_encoding=output_format_encoding,
+            output_format_bit_rate=output_format_bit_rate,
+            request_options=request_options,
+        )
+        audio_bytes = b"".join(result)
 
     output_file = create_output_file(OUTPUT_DIRECTORY, "voice_change",
                                         output_format_container)
-
-    audio_bytes = b"".join(result)
     with output_file.open("wb") as f:
         f.write(audio_bytes)
 
-        return GeneratedAudioResult(file_path=output_file)
+    return GeneratedAudioResult(file_path=str(output_file))
 
 @mcp.tool(description="""
         Create a new voice from an existing voice localized to a new language and dialect.
@@ -248,15 +249,15 @@ def localize_voice(
     dialect: typing.Optional[LocalizeDialectParams] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
-    result = client.voices.localize(
+    return client.voices.localize(
         voice_id=voice_id,
         name=name,
         description=description,
         language=language,
         original_speaker_gender=original_speaker_gender,
         dialect=dialect,
-        request_options=request_options)
-    return VoiceMetadata(**result.dict())
+        request_options=request_options,
+    )
 
 
 @mcp.tool(description="""
@@ -272,9 +273,8 @@ def delete_voice(
     voice_id: str,
     request_options: typing.Optional[RequestOptions] = None
 ) -> DeleteVoiceResult:
-    result = client.voices.delete(id=voice_id,
-                                request_options=request_options)
-    return DeleteVoiceResult(**result.dict())
+    client.voices.delete(id=voice_id, request_options=request_options)
+    return DeleteVoiceResult(success=True)
 
 @mcp.tool(description="""
         Parameters
@@ -289,8 +289,7 @@ def get_voice(
         voice_id: str,
         request_options: typing.Optional[RequestOptions] = None
 ) -> Voice:
-    result = client.voices.get(id=voice_id, request_options=request_options)
-    return Voice(**result.dict())
+    return client.voices.get(id=voice_id, request_options=request_options)
 
 
 @mcp.tool(description="""
@@ -312,12 +311,13 @@ def update_voice(
         name: str,
         description: str,
         request_options: typing.Optional[RequestOptions] = None
-) -> VoiceMetadata:
-    result = client.voices.update(id=voice_id,
-                                name=name,
-                                description=description,
-                                request_options=request_options)
-    return VoiceMetadata(**result.dict())
+) -> Voice:
+    return client.voices.update(
+        id=voice_id,
+        name=name,
+        description=description,
+        request_options=request_options,
+    )
 
 @mcp.tool(description="""
         Clone a voice from an audio clip. This endpoint has two modes, stability and similarity.
@@ -354,13 +354,15 @@ def clone_voice(
     description: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
-    result = client.voices.clone(clip=open(file_path, "rb"),
-                                name=name,
-                                language=language,
-                                mode=mode,
-                                description=description,
-                                request_options=request_options)
-    return VoiceMetadata(**result.dict())
+    with open(file_path, "rb") as clip:
+        return client.voices.clone(
+            clip=clip,
+            name=name,
+            language=language,
+            mode=mode,
+            description=description,
+            request_options=request_options,
+        )
 
 @mcp.tool(description="""
         Parameters

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Smoke-test all cartesia-mcp tool handlers (direct function calls)."""
+"""Smoke-test all cartesia-mcp tool handlers (direct function calls).
+
+Safety: only delete voices created in this run (clone/localize). Never delete
+catalog or pre-existing user voices — use public voice IDs for read/generation
+only, then create ephemeral test voices and delete those by ID.
+"""
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 import time
@@ -15,8 +19,12 @@ from typing import Any
 OUTPUT_DIR = os.environ.get(
     "OUTPUT_DIRECTORY", os.path.join(os.path.dirname(__file__), "..", "test-output")
 )
+# Public catalog voices — read / TTS / infill / voice_change only; never delete.
 SAMPLE_VOICE_ID = "ef191366-f52f-447a-a398-ed8c0f2943a1"  # Archie
 ALT_VOICE_ID = "47c38ca4-5f35-497b-b1a3-415245fb35e1"  # Daniel
+PROTECTED_VOICE_IDS = frozenset({SAMPLE_VOICE_ID, ALT_VOICE_ID})
+TEST_VOICE_NAME_PREFIX = "MCP Test"
+TEST_LOCALIZED_NAME_PREFIX = "MCP Localized"
 WAV_FORMAT = {
     "container": "wav",
     "encoding": "pcm_s16le",
@@ -31,6 +39,15 @@ def ok(name: str, detail: str = "") -> None:
 def fail(name: str, err: BaseException) -> None:
     print(f"  FAIL {name}: {err}")
     traceback.print_exc()
+
+
+def assert_safe_to_delete(voice_id: str, name: str, *, created_this_run: bool) -> None:
+    if voice_id in PROTECTED_VOICE_IDS:
+        raise RuntimeError(f"refusing to delete protected catalog voice {voice_id}")
+    if not created_this_run:
+        raise RuntimeError(f"refusing to delete voice not created in this run: {voice_id}")
+    if not (name.startswith(TEST_VOICE_NAME_PREFIX) or name.startswith(TEST_LOCALIZED_NAME_PREFIX)):
+        raise RuntimeError(f"refusing to delete voice with unexpected name {name!r}")
 
 
 def assert_str_path(result: dict[str, Any], tool: str) -> str:
@@ -55,7 +72,9 @@ def main() -> int:
 
     failures: list[str] = []
     cloned_voice_id: str | None = None
+    cloned_voice_name: str | None = None
     localized_voice_id: str | None = None
+    localized_voice_name: str | None = None
     tts_path: str | None = None
     run_id = str(int(time.time()))
 
@@ -111,7 +130,7 @@ def main() -> int:
     )
 
     if tts_path and os.path.isfile(tts_path):
-        clone_name = f"MCP Test Clone {run_id}"
+        clone_name = f"{TEST_VOICE_NAME_PREFIX} Clone {run_id}"
         clone_result = run(
             "clone_voice",
             lambda: s.clone_voice(
@@ -124,6 +143,7 @@ def main() -> int:
         )
         if clone_result:
             cloned_voice_id = getattr(clone_result, "id", None)
+            cloned_voice_name = getattr(clone_result, "name", clone_name)
             ok("clone_voice", f"id={cloned_voice_id}")
 
             if cloned_voice_id:
@@ -170,11 +190,12 @@ def main() -> int:
                 fail("infill validation", e)
                 failures.append("infill(validation)")
 
+    localized_name = f"{TEST_LOCALIZED_NAME_PREFIX} {run_id}"
     loc_result = run(
         "localize_voice",
         lambda: s.localize_voice(
             voice_id=SAMPLE_VOICE_ID,
-            name=f"MCP Localized {run_id}",
+            name=localized_name,
             description="Temporary localized voice from MCP test",
             language="es",
             original_speaker_gender="male",
@@ -182,17 +203,26 @@ def main() -> int:
     )
     if loc_result:
         localized_voice_id = getattr(loc_result, "id", None)
+        localized_voice_name = getattr(loc_result, "name", localized_name)
         ok("localize_voice", f"id={localized_voice_id}")
 
-    for vid, label in [
-        (localized_voice_id, "localized"),
-        (cloned_voice_id, "cloned"),
+    # Only delete voices we created above — never catalog or existing user voices.
+    for vid, name, label in [
+        (localized_voice_id, localized_voice_name, "localized"),
+        (cloned_voice_id, cloned_voice_name, "cloned"),
     ]:
-        if vid:
-            run(
-                f"delete_voice({label})",
-                lambda voice_id=vid: s.delete_voice(voice_id=voice_id),
-            )
+        if not vid or not name:
+            continue
+        try:
+            assert_safe_to_delete(vid, name, created_this_run=True)
+        except RuntimeError as e:
+            fail(f"delete_voice({label}) precheck", e)
+            failures.append(f"delete_voice({label})")
+            continue
+        run(
+            f"delete_voice({label})",
+            lambda voice_id=vid: s.delete_voice(voice_id=voice_id),
+        )
 
     print()
     if failures:

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Smoke-test all cartesia-mcp tool handlers (direct function calls)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+from typing import Any
+
+# Run from repo root: uv run python scripts/test_all_tools.py
+
+OUTPUT_DIR = os.environ.get(
+    "OUTPUT_DIRECTORY", os.path.join(os.path.dirname(__file__), "..", "test-output")
+)
+SAMPLE_VOICE_ID = "ef191366-f52f-447a-a398-ed8c0f2943a1"  # Archie
+ALT_VOICE_ID = "47c38ca4-5f35-497b-b1a3-415245fb35e1"  # Daniel
+WAV_FORMAT = {
+    "container": "wav",
+    "encoding": "pcm_s16le",
+    "sample_rate": 44100,
+}
+
+
+def ok(name: str, detail: str = "") -> None:
+    print(f"  OK  {name}" + (f" — {detail}" if detail else ""))
+
+
+def fail(name: str, err: BaseException) -> None:
+    print(f"  FAIL {name}: {err}")
+    traceback.print_exc()
+
+
+def assert_str_path(result: dict[str, Any], tool: str) -> str:
+    path = result["file_path"]
+    if not isinstance(path, str):
+        raise TypeError(f"{tool}: file_path must be str, got {type(path)}")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"{tool}: missing output file {path}")
+    return path
+
+
+def main() -> int:
+    if not os.environ.get("CARTESIA_API_KEY"):
+        print("CARTESIA_API_KEY is required", file=sys.stderr)
+        return 1
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.environ["OUTPUT_DIRECTORY"] = os.path.abspath(OUTPUT_DIR)
+
+    # Import after OUTPUT_DIRECTORY is set (server reads env at import).
+    import cartesia_mcp.server as s  # noqa: WPS433
+
+    failures: list[str] = []
+    cloned_voice_id: str | None = None
+    localized_voice_id: str | None = None
+    tts_path: str | None = None
+    run_id = str(int(time.time()))
+
+    def run(name: str, fn) -> Any:
+        try:
+            result = fn()
+            ok(name)
+            return result
+        except Exception as e:  # noqa: BLE001
+            fail(name, e)
+            failures.append(name)
+            return None
+
+    print(f"Output directory: {os.environ['OUTPUT_DIRECTORY']}\n")
+
+    pager = run("list_voices", lambda: s.list_voices(limit=3))
+    if pager is not None:
+        items = list(pager.items) if hasattr(pager, "items") else list(pager)
+        if not items:
+            failures.append("list_voices(empty)")
+            print("  FAIL list_voices: no items")
+        else:
+            ok("list_voices", f"{len(items)} voices")
+
+    run(
+        "get_voice",
+        lambda: s.get_voice(voice_id=SAMPLE_VOICE_ID),
+    )
+
+    tts_result = run(
+        "text_to_speech",
+        lambda: s.text_to_speech(
+            transcript=(
+                "This is a longer Cartesia MCP smoke test clip. "
+                "We need several seconds of speech for voice cloning to succeed."
+            ),
+            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            output_format=WAV_FORMAT,
+            language="en",
+        ),
+    )
+    if tts_result:
+        try:
+            tts_path = assert_str_path(tts_result, "text_to_speech")
+            ok("text_to_speech output", tts_path)
+        except Exception as e:  # noqa: BLE001
+            fail("text_to_speech validation", e)
+            failures.append("text_to_speech(validation)")
+
+    # clone_voice needs ~5s+ audio; use TTS output when available.
+    sample_wav = tts_path or os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "hi-grant-archie.wav")
+    )
+
+    if tts_path and os.path.isfile(tts_path):
+        clone_name = f"MCP Test Clone {run_id}"
+        clone_result = run(
+            "clone_voice",
+            lambda: s.clone_voice(
+                file_path=sample_wav,
+                name=clone_name,
+                language="en",
+                mode="similarity",
+                description="Temporary MCP integration test voice",
+            ),
+        )
+        if clone_result:
+            cloned_voice_id = getattr(clone_result, "id", None)
+            ok("clone_voice", f"id={cloned_voice_id}")
+
+            if cloned_voice_id:
+                run(
+                    "update_voice",
+                    lambda: s.update_voice(
+                        voice_id=cloned_voice_id,
+                        name=f"{clone_name} (updated)",
+                        description="Updated by MCP smoke test",
+                    ),
+                )
+    else:
+        print(f"  SKIP clone_voice / update_voice — no sample wav at {sample_wav}")
+        failures.append("clone_voice(skipped)")
+
+    if tts_path and os.path.isfile(tts_path):
+        run(
+            "voice_change",
+            lambda: s.voice_change(
+                file_path=tts_path,
+                voice_id=ALT_VOICE_ID,
+                output_format_container="wav",
+                output_format_sample_rate=44100,
+                output_format_encoding="pcm_s16le",
+            ),
+        )
+        infill_result = run(
+            "infill",
+            lambda: s.infill(
+                language="en",
+                transcript=" and ",
+                voice_id=SAMPLE_VOICE_ID,
+                output_format_container="wav",
+                output_format_sample_rate=44100,
+                output_format_encoding="pcm_s16le",
+                left_audio_file_path=tts_path,
+                right_audio_file_path=tts_path,
+            ),
+        )
+        if infill_result:
+            try:
+                assert_str_path(infill_result, "infill")
+            except Exception as e:  # noqa: BLE001
+                fail("infill validation", e)
+                failures.append("infill(validation)")
+
+    loc_result = run(
+        "localize_voice",
+        lambda: s.localize_voice(
+            voice_id=SAMPLE_VOICE_ID,
+            name=f"MCP Localized {run_id}",
+            description="Temporary localized voice from MCP test",
+            language="es",
+            original_speaker_gender="male",
+        ),
+    )
+    if loc_result:
+        localized_voice_id = getattr(loc_result, "id", None)
+        ok("localize_voice", f"id={localized_voice_id}")
+
+    for vid, label in [
+        (localized_voice_id, "localized"),
+        (cloned_voice_id, "cloned"),
+    ]:
+        if vid:
+            run(
+                f"delete_voice({label})",
+                lambda voice_id=vid: s.delete_voice(voice_id=voice_id),
+            )
+
+    print()
+    if failures:
+        print(f"Failed: {', '.join(failures)}")
+        return 1
+    print("All tools passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-850/add-smoke-tests-for-mcp

## Summary

Smoke-testing all nine MCP tools found handler bugs that caused tool calls to fail after successful API requests. This PR fixes return-type and response-handling issues and adds a guarded integration smoke test so audio and voice tools work reliably from MCP clients like Cursor.

## Changes

- Return `str(output_file)` from `text_to_speech`, `infill`, and `voice_change` (fixes FastMCP validation on `GeneratedAudioResult`)
- Fix `delete_voice` to return `{ success: true }` on 204 No Content
- Fix `update_voice` to return the SDK `Voice` model directly
- Return SDK models directly from `get_voice`, `clone_voice`, and `localize_voice`
- Read voice-changer input inside the file context manager so streaming does not hit a closed file
- Add `scripts/test_all_tools.py` with guarded deletes (only ephemeral test voices)
- Document smoke test in README; ignore `test-output/` in git

## Test plan

- [x] `uv run python scripts/test_all_tools.py` — all 9 tools pass