### PR TITLE
chore: default TTS and infill to sonic-3.5

### DIFF
--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -56,7 +56,7 @@ def text_to_speech(
     transcript: str,
     voice: TtsRequestVoiceSpecifierParams,
     output_format: OutputFormatParams,
-    model_id: typing.Optional[str] = "sonic-3",
+    model_id: typing.Optional[str] = "sonic-3.5",
     language: typing.Optional[SupportedLanguage] = None,
     duration: typing.Optional[float] = None,
     request_options: typing.Optional[RequestOptions] = None,
@@ -143,7 +143,7 @@ def infill(
                         "rb") if right_audio_file_path else None
 
     result = client.infill.bytes(
-        model_id="sonic-3",
+        model_id="sonic-3.5",
         language=language,
         transcript=transcript,
         voice_id=voice_id,


### PR DESCRIPTION
## Summary

Updates the Cartesia MCP server so `text_to_speech` and `infill` default to **Sonic 3.5** (`sonic-3.5`) instead of Sonic 3. Callers can still override `model_id` explicitly.

## Changes

- `text_to_speech`: default `model_id` → `sonic-3.5`
- `infill`: hardcoded `model_id` → `sonic-3.5`

## Test plan

- [ ] `uv run python scripts/test_all_tools.py` (requires `CARTESIA_API_KEY`)
- [ ] `text_to_speech` via MCP without `model_id` uses Sonic 3.5

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only default model IDs change; callers can still override `model_id` on TTS, with possible output differences for omitting callers.
> 
> **Overview**
> The Cartesia MCP server now defaults TTS and infill generation to **Sonic 3.5** (`sonic-3.5`) instead of Sonic 3 (`sonic-3`).
> 
> **`text_to_speech`** uses `sonic-3.5` as the default when callers omit `model_id`. **`infill`** always passes `model_id="sonic-3.5"` to the Cartesia infill API. Explicit `model_id` on `text_to_speech` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79b5f9c40fa54d0d721c1bfe2a3b72acfffe3142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->