### PR TITLE
feat: add language and search filters to list_voices

### DIFF
--- a/cartesia_mcp/custom_types/__init__.py
+++ b/cartesia_mcp/custom_types/__init__.py
@@ -1,6 +1,6 @@
-from .tool_results import GeneratedAudioResult, DeleteVoiceResult
+from .tool_results import GeneratedAudioResult, DeleteVoiceResult, ListVoicesResult
 from .tool_type import ToolType
 
 __all__ = [
-    "GeneratedAudioResult", "DeleteVoiceResult", "ToolType"
+    "GeneratedAudioResult", "DeleteVoiceResult", "ListVoicesResult", "ToolType"
 ]

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -9,3 +9,9 @@ class GeneratedAudioResult(typing.TypedDict):
     file_path: str
 
 
+class ListVoicesResult(typing.TypedDict, total=False):
+    data: typing.List[typing.Any]
+    has_more: bool
+    next_page: str
+
+

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -6,9 +6,8 @@ import os
 import typing
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
-from cartesia_mcp.custom_types import GeneratedAudioResult, DeleteVoiceResult
+from cartesia_mcp.custom_types import GeneratedAudioResult, DeleteVoiceResult, ListVoicesResult
 from cartesia import Cartesia
-from cartesia.core.pagination import SyncPager
 from cartesia.voices.requests import LocalizeDialectParams
 from cartesia.voices.types import VoiceMetadata, GenderPresentation, Gender, CloneMode, Voice
 from cartesia.voice_changer.types import OutputFormatContainer
@@ -16,7 +15,7 @@ from cartesia.tts.types import SupportedLanguage, RawEncoding
 from cartesia.tts.requests import OutputFormatParams, TtsRequestVoiceSpecifierParams
 from cartesia.core.request_options import RequestOptions
 
-from cartesia_mcp.utils import create_output_file
+from cartesia_mcp.utils import create_output_file, build_list_voices_request_options, voice_list_page_to_result
 
 load_dotenv()
 
@@ -391,6 +390,17 @@ def clone_voice(
         gender : typing.Optional[GenderPresentation]
             The gender presentation of the voices to return.
 
+        language : typing.Optional[str]
+            Filter voices by language or locale, such as `en`, `it`, or `en_GB`.
+            A locale returns accents for that region; a language alone returns all accents
+            for that language. Both `-` and `_` separators are accepted.
+
+        q : typing.Optional[str]
+            Search voices by name, description, or voice ID.
+
+        expand : typing.Optional[typing.Sequence[str]]
+            Additional fields to include in the response, such as `preview_file_url`.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
         """)
@@ -401,16 +411,27 @@ def list_voices(
     is_owner: typing.Optional[bool] = None,
     is_starred: typing.Optional[bool] = None,
     gender: typing.Optional[GenderPresentation] = None,
+    language: typing.Optional[str] = None,
+    q: typing.Optional[str] = None,
+    expand: typing.Optional[typing.Sequence[str]] = None,
     request_options: typing.Optional[RequestOptions] = None,
-) -> SyncPager[Voice]:
-    result = client.voices.list(limit=limit,
-                                gender=gender,
-                                is_owner=is_owner,
-                                is_starred=is_starred,
-                                starting_after=starting_after,
-                                ending_before=ending_before,
-                                request_options=request_options)
-    return result
+) -> ListVoicesResult:
+    merged_request_options = build_list_voices_request_options(
+        request_options,
+        language=language,
+        q=q,
+        expand=expand,
+    )
+    pager = client.voices.list(
+        limit=limit,
+        gender=gender,
+        is_owner=is_owner,
+        is_starred=is_starred,
+        starting_after=starting_after,
+        ending_before=ending_before,
+        request_options=merged_request_options,
+    )
+    return voice_list_page_to_result(pager)
 
 def main():
     mcp.run(transport="stdio")

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -1,8 +1,12 @@
 import os
 import datetime
+import typing
 from pathlib import Path
-from cartesia_mcp.custom_types import ToolType
+from cartesia_mcp.custom_types import ToolType, ListVoicesResult
+from cartesia.core.pagination import SyncPager
+from cartesia.core.request_options import RequestOptions
 from cartesia.voice_changer.types import OutputFormatContainer
+from cartesia.voices.types import Voice
 
 def create_output_file(output_directory: str, tool_type: ToolType,
                        extension: OutputFormatContainer) -> Path:
@@ -15,3 +19,35 @@ def create_output_file(output_directory: str, tool_type: ToolType,
             f"Output directory {dir_path} is not writable")
 
     return dir_path / f"{tool_type}_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.{extension}"
+
+
+def build_list_voices_request_options(
+    request_options: typing.Optional[RequestOptions],
+    *,
+    language: typing.Optional[str] = None,
+    q: typing.Optional[str] = None,
+    expand: typing.Optional[typing.Sequence[str]] = None,
+) -> typing.Optional[RequestOptions]:
+    extra_query: dict[str, typing.Any] = {}
+    if language is not None:
+        extra_query["language"] = language
+    if q is not None:
+        extra_query["q"] = q
+    if expand:
+        extra_query["expand[]"] = list(expand)
+    if not extra_query:
+        return request_options
+
+    merged: RequestOptions = dict(request_options or {})
+    base = dict(merged.get("additional_query_parameters") or {})
+    base.update(extra_query)
+    merged["additional_query_parameters"] = base
+    return merged
+
+
+def voice_list_page_to_result(pager: SyncPager[Voice]) -> ListVoicesResult:
+    data = [voice.model_dump(mode="json") for voice in pager.items]
+    result: ListVoicesResult = {"data": data, "has_more": pager.has_next}
+    if pager.has_next and data:
+        result["next_page"] = data[-1]["id"]
+    return result

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -90,14 +90,26 @@ def main() -> int:
 
     print(f"Output directory: {os.environ['OUTPUT_DIRECTORY']}\n")
 
-    pager = run("list_voices", lambda: s.list_voices(limit=3))
-    if pager is not None:
-        items = list(pager.items) if hasattr(pager, "items") else list(pager)
+    result = run("list_voices", lambda: s.list_voices(limit=3))
+    if result is not None:
+        items = result.get("data", []) if isinstance(result, dict) else []
         if not items:
             failures.append("list_voices(empty)")
             print("  FAIL list_voices: no items")
         else:
             ok("list_voices", f"{len(items)} voices")
+
+    it_result = run(
+        "list_voices(language=it)",
+        lambda: s.list_voices(language="it", is_owner=False, limit=20),
+    )
+    if it_result is not None:
+        items = it_result.get("data", [])
+        if not items or any(v.get("language") != "it" for v in items):
+            failures.append("list_voices(language=it)")
+            print("  FAIL list_voices(language=it): missing or non-Italian voices")
+        else:
+            ok("list_voices(language=it)", f"{len(items)} Italian catalog voices")
 
     run(
         "get_voice",


### PR DESCRIPTION
## Summary

The `list_voices` MCP tool now supports common [List Voices](https://docs.cartesia.ai/api-reference/voices/list) API filters so agents can query by language, search text, and optional response expansions without paginating the full catalog client-side. Results are returned as a JSON-serializable page object instead of a `SyncPager`, which fixes MCP schema/serialization issues.

## Changes

- Add `language`, `q`, and `expand` parameters to `list_voices`
- Pass new filters through `request_options.additional_query_parameters` until the SDK exposes them natively
- Return `{ data, has_more, next_page? }` via a new `ListVoicesResult` type
- Extend smoke tests to cover `language=it` catalog filtering

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized MCP tool and smoke-test changes only; no auth or sensitive data paths. Callers must adapt to the new list_voices return shape instead of SyncPager.
> 
> **Overview**
> The **`list_voices`** MCP tool now accepts **`language`**, **`q`**, and **`expand`** filters aligned with the Cartesia List Voices API. Filters that are not yet first-class on the SDK are sent via **`request_options.additional_query_parameters`** (including **`expand[]`** for expansions).
> 
> The tool **no longer returns a `SyncPager`**. It returns a JSON-friendly **`ListVoicesResult`** with **`data`** (voice dicts from **`model_dump`**), **`has_more`**, and optional **`next_page`** (last voice id when another page exists). Shared helpers **`build_list_voices_request_options`** and **`voice_list_page_to_result`** live in **`utils`**.
> 
> Smoke tests were updated for the new shape and add a **`list_voices(language="it")`** check on catalog voices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92cfaa5ae3c470ecde0ce8ce831ebda5a1e8dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->