### PR TITLE
Add optional CARTESIA_ADMIN_API_KEY for admin-only tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run pytest
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [
 
 - **[uv](https://docs.astral.sh/uv/)** — runs the server via `uvx` with no global install
 - **Python 3.13+** (installed automatically by `uvx`)
-- A **[Cartesia API key](https://play.cartesia.ai/keys)**
+- A **[Cartesia API key](https://play.cartesia.ai/keys)** for TTS, STT, voices, and related APIs
+- Optionally, an **[admin API key](https://play.cartesia.ai/keys)** (Keys → Admin) for management tools such as `get_credit_usage`. Admin keys and standard keys are separate credentials; each only works on its own route class.
 
 ## Setup
 
-Add this to your MCP config. You only need your API key.
+Add this to your MCP config with your standard API key.
 
 **Cursor** — `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` globally.
 
@@ -66,7 +67,7 @@ Ask your agent things like:
 | `get_pronunciation_dict` | Get a pronunciation dictionary by ID |
 | `update_pronunciation_dict` | Update a pronunciation dictionary |
 | `delete_pronunciation_dict` | Delete a pronunciation dictionary |
-| `get_credit_usage` | Credit usage over time (admin API key) |
+| `get_credit_usage` | Credit usage over time (`CARTESIA_ADMIN_API_KEY`) |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.
 
@@ -96,6 +97,15 @@ By default, generated audio is written to the server's working directory. To cho
 ### Local audio files
 
 Tools like `speech_to_text` and `voice_change` need paths to existing audio files on disk. Pass the full path to each file when prompting your agent.
+
+### Admin API key
+
+Some tools call [management endpoints](https://docs.cartesia.ai/api-reference/usage/credits) that accept **admin** API keys only (`sk_car_admin_...`). Set `CARTESIA_ADMIN_API_KEY` in `env` alongside `CARTESIA_API_KEY`:
+
+- `CARTESIA_API_KEY` — TTS, STT, voices, pronunciation dictionaries, voice changer, etc.
+- `CARTESIA_ADMIN_API_KEY` — optional; required for `get_credit_usage` today. Admin keys do not work on generation routes, and standard keys do not work on admin routes.
+
+Mint admin keys in the Playground under **Keys → Admin** (org admins only).
 
 ### API version
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and retu
 
 ## Testing
 
+Unit tests (no API keys):
+
+```sh
+uv sync --dev
+uv run pytest
+```
+
 Smoke-test all tools (requires `CARTESIA_API_KEY`):
 
 ```sh

--- a/cartesia_mcp/config.py
+++ b/cartesia_mcp/config.py
@@ -1,0 +1,52 @@
+"""Environment and API key configuration for the MCP server."""
+
+from __future__ import annotations
+
+import os
+import typing
+
+from cartesia_mcp.sdk_setup import is_admin_api_key
+
+ADMIN_HTTP_REQUIRED_MESSAGE = (
+    "This tool requires CARTESIA_ADMIN_API_KEY. Admin keys are separate from "
+    "standard API keys and only work on management endpoints (e.g. GET /usage/credits). "
+    "Create one in the Playground under Keys → Admin."
+)
+
+
+def env_or_none(
+    name: str,
+    environ: typing.Mapping[str, str | None] | None = None,
+) -> str | None:
+    source = os.environ if environ is None else environ
+    value = source.get(name)
+    if value is None or not value.strip():
+        return None
+    return value.strip()
+
+
+def validate_api_keys(
+    api_key: str | None,
+    admin_api_key: str | None,
+) -> tuple[str, str | None]:
+    if not api_key:
+        raise ValueError("CARTESIA_API_KEY is required")
+
+    if is_admin_api_key(api_key):
+        raise ValueError(
+            "CARTESIA_API_KEY must be a standard API key (sk_car_...), not an admin key. "
+            "Use CARTESIA_ADMIN_API_KEY for admin-only tools such as get_credit_usage."
+        )
+
+    if admin_api_key is not None and not is_admin_api_key(admin_api_key):
+        raise ValueError(
+            "CARTESIA_ADMIN_API_KEY must be an admin API key (sk_car_admin_...)."
+        )
+
+    return api_key, admin_api_key
+
+
+def ensure_admin_http(admin_http: typing.Any) -> typing.Any:
+    if admin_http is None:
+        raise ValueError(ADMIN_HTTP_REQUIRED_MESSAGE)
+    return admin_http

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -4,6 +4,9 @@ HTTP helpers for Cartesia endpoints not generated on the Fern v2 Python SDK.
 The pinned `cartesia` 2.x client exposes tts, stt, voices, and voice_changer
 only — not pronunciation dictionaries or usage/credits. These thin wrappers call the
 same httpx stack as the SDK (shared auth, base URL, and Cartesia-Version header).
+
+`get_usage_credits` must be called with an HTTP client authenticated using an admin API key
+(`CARTESIA_ADMIN_API_KEY`); standard API keys are rejected on `/usage/*`.
 """
 
 from __future__ import annotations

--- a/cartesia_mcp/sdk_setup.py
+++ b/cartesia_mcp/sdk_setup.py
@@ -7,6 +7,13 @@ from cartesia.core.http_client import HttpClient
 
 from cartesia_mcp.api_version import CARTESIA_VERSION
 
+# Admin keys use sk_car_admin_<id>.<secret>; standard keys use sk_car_<id>.<secret>.
+ADMIN_API_KEY_PREFIX = "sk_car_admin_"
+
+
+def is_admin_api_key(api_key: str) -> bool:
+    return api_key.startswith(ADMIN_API_KEY_PREFIX)
+
 
 def create_cartesia_client(api_key: str) -> Cartesia:
     client = Cartesia(api_key=api_key)

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -28,7 +28,11 @@ from cartesia.core.request_options import RequestOptions
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
 from cartesia_mcp.extra_api import UsageInterval
-from cartesia_mcp.sdk_setup import create_cartesia_client, get_http
+from cartesia_mcp.sdk_setup import (
+    create_cartesia_client,
+    get_http,
+    is_admin_api_key,
+)
 from cartesia_mcp.utils import (
     build_list_voices_request_options,
     create_output_file,
@@ -39,15 +43,42 @@ from cartesia_mcp.utils import (
 load_dotenv()
 
 CARTESIA_API_KEY = os.getenv("CARTESIA_API_KEY")
+CARTESIA_ADMIN_API_KEY = os.getenv("CARTESIA_ADMIN_API_KEY")
 
 if not CARTESIA_API_KEY:
     raise ValueError("CARTESIA_API_KEY is required")
+
+if is_admin_api_key(CARTESIA_API_KEY):
+    raise ValueError(
+        "CARTESIA_API_KEY must be a standard API key (sk_car_...), not an admin key. "
+        "Use CARTESIA_ADMIN_API_KEY for admin-only tools such as get_credit_usage."
+    )
+
+if CARTESIA_ADMIN_API_KEY is not None and not is_admin_api_key(CARTESIA_ADMIN_API_KEY):
+    raise ValueError(
+        "CARTESIA_ADMIN_API_KEY must be an admin API key (sk_car_admin_...)."
+    )
 
 OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
 client = create_cartesia_client(CARTESIA_API_KEY)
 http = get_http(client)
+admin_http = (
+    get_http(create_cartesia_client(CARTESIA_ADMIN_API_KEY))
+    if CARTESIA_ADMIN_API_KEY
+    else None
+)
 mcp = FastMCP("Cartesia")
+
+
+def _require_admin_http():
+    if admin_http is None:
+        raise ValueError(
+            "This tool requires CARTESIA_ADMIN_API_KEY. Admin keys are separate from "
+            "standard API keys and only work on management endpoints (e.g. GET /usage/credits). "
+            "Create one in the Playground under Keys → Admin."
+        )
+    return admin_http
 
 
 def _build_generation_config(
@@ -473,7 +504,8 @@ def speech_to_text(
 @mcp.tool(description="""
         Returns credit usage over time (`GET /usage/credits`).
 
-        Requires an **admin** API key. Optional `start_ts` and `end_ts` are RFC 3339 datetimes;
+        Requires **CARTESIA_ADMIN_API_KEY** (admin API keys cannot be used as CARTESIA_API_KEY).
+        Optional `start_ts` and `end_ts` are RFC 3339 datetimes;
         `interval` buckets results by `day`, `week`, or `month`.
 
         Parameters
@@ -494,7 +526,7 @@ def get_credit_usage(
     api_key_id: typing.Optional[str] = None,
 ) -> dict[str, typing.Any]:
     return extra_api.get_usage_credits(
-        http,
+        _require_admin_http(),
         start_ts=start_ts,
         end_ts=end_ts,
         interval=interval,

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -28,11 +28,8 @@ from cartesia.core.request_options import RequestOptions
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
 from cartesia_mcp.extra_api import UsageInterval
-from cartesia_mcp.sdk_setup import (
-    create_cartesia_client,
-    get_http,
-    is_admin_api_key,
-)
+from cartesia_mcp.config import ensure_admin_http, env_or_none, validate_api_keys
+from cartesia_mcp.sdk_setup import create_cartesia_client, get_http
 from cartesia_mcp.utils import (
     build_list_voices_request_options,
     create_output_file,
@@ -42,30 +39,10 @@ from cartesia_mcp.utils import (
 
 load_dotenv()
 
-
-def _env_or_none(name: str) -> str | None:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        return None
-    return value.strip()
-
-
-CARTESIA_API_KEY = _env_or_none("CARTESIA_API_KEY")
-CARTESIA_ADMIN_API_KEY = _env_or_none("CARTESIA_ADMIN_API_KEY")
-
-if not CARTESIA_API_KEY:
-    raise ValueError("CARTESIA_API_KEY is required")
-
-if is_admin_api_key(CARTESIA_API_KEY):
-    raise ValueError(
-        "CARTESIA_API_KEY must be a standard API key (sk_car_...), not an admin key. "
-        "Use CARTESIA_ADMIN_API_KEY for admin-only tools such as get_credit_usage."
-    )
-
-if CARTESIA_ADMIN_API_KEY is not None and not is_admin_api_key(CARTESIA_ADMIN_API_KEY):
-    raise ValueError(
-        "CARTESIA_ADMIN_API_KEY must be an admin API key (sk_car_admin_...)."
-    )
+CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY = validate_api_keys(
+    env_or_none("CARTESIA_API_KEY"),
+    env_or_none("CARTESIA_ADMIN_API_KEY"),
+)
 
 OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
@@ -80,13 +57,7 @@ mcp = FastMCP("Cartesia")
 
 
 def _require_admin_http():
-    if admin_http is None:
-        raise ValueError(
-            "This tool requires CARTESIA_ADMIN_API_KEY. Admin keys are separate from "
-            "standard API keys and only work on management endpoints (e.g. GET /usage/credits). "
-            "Create one in the Playground under Keys → Admin."
-        )
-    return admin_http
+    return ensure_admin_http(admin_http)
 
 
 def _build_generation_config(

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -42,8 +42,16 @@ from cartesia_mcp.utils import (
 
 load_dotenv()
 
-CARTESIA_API_KEY = os.getenv("CARTESIA_API_KEY")
-CARTESIA_ADMIN_API_KEY = os.getenv("CARTESIA_ADMIN_API_KEY")
+
+def _env_or_none(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return None
+    return value.strip()
+
+
+CARTESIA_API_KEY = _env_or_none("CARTESIA_API_KEY")
+CARTESIA_ADMIN_API_KEY = _env_or_none("CARTESIA_ADMIN_API_KEY")
 
 if not CARTESIA_API_KEY:
     raise ValueError("CARTESIA_API_KEY is required")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ dependencies = [
 [project.scripts]
 cartesia-mcp = "cartesia_mcp.server:main"
 
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -162,7 +162,7 @@ def main() -> int:
                 failures.append("speech_to_text(empty)")
                 print("  FAIL speech_to_text: empty transcript")
 
-    if os.environ.get("CARTESIA_ADMIN_API_KEY"):
+    if s.admin_http is not None:
         run("get_credit_usage", lambda: s.get_credit_usage())
     else:
         print("  SKIP get_credit_usage — set CARTESIA_ADMIN_API_KEY to test")

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -162,11 +162,10 @@ def main() -> int:
                 failures.append("speech_to_text(empty)")
                 print("  FAIL speech_to_text: empty transcript")
 
-    run(
-        "get_credit_usage",
-        lambda: s.get_credit_usage(),
-        optional=True,
-    )
+    if os.environ.get("CARTESIA_ADMIN_API_KEY"):
+        run("get_credit_usage", lambda: s.get_credit_usage())
+    else:
+        print("  SKIP get_credit_usage — set CARTESIA_ADMIN_API_KEY to test")
 
     dict_name = f"{TEST_DICT_NAME_PREFIX} {run_id}"
     create_dict = run(

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -66,7 +66,9 @@ def assert_str_path(result: dict[str, Any], tool: str) -> str:
 
 
 def main() -> int:
-    if not os.environ.get("CARTESIA_API_KEY"):
+    from cartesia_mcp.config import env_or_none
+
+    if env_or_none("CARTESIA_API_KEY", os.environ) is None:
         print("CARTESIA_API_KEY is required", file=sys.stderr)
         return 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,75 @@
+"""Unit tests for API key env parsing and validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from cartesia_mcp.config import (
+    ADMIN_HTTP_REQUIRED_MESSAGE,
+    ensure_admin_http,
+    env_or_none,
+    validate_api_keys,
+)
+from cartesia_mcp.sdk_setup import is_admin_api_key
+
+STANDARD_KEY = "sk_car_testId1234567890ab.secretPartHere1234567890abcdefghij"
+ADMIN_KEY = "sk_car_admin_testId1234567890ab.secretPartHere1234567890abcdefghij"
+
+
+class TestEnvOrNone:
+    def test_missing(self) -> None:
+        assert env_or_none("CARTESIA_API_KEY", {}) is None
+
+    def test_empty_string(self) -> None:
+        assert env_or_none("CARTESIA_API_KEY", {"CARTESIA_API_KEY": ""}) is None
+
+    def test_whitespace_only(self) -> None:
+        assert env_or_none("CARTESIA_API_KEY", {"CARTESIA_API_KEY": "   "}) is None
+
+    def test_strips_value(self) -> None:
+        assert env_or_none("CARTESIA_API_KEY", {"CARTESIA_API_KEY": f"  {STANDARD_KEY}  "}) == STANDARD_KEY
+
+
+class TestIsAdminApiKey:
+    def test_admin_prefix(self) -> None:
+        assert is_admin_api_key(ADMIN_KEY) is True
+
+    def test_standard_prefix(self) -> None:
+        assert is_admin_api_key(STANDARD_KEY) is False
+
+
+class TestValidateApiKeys:
+    def test_requires_standard_key(self) -> None:
+        with pytest.raises(ValueError, match="CARTESIA_API_KEY is required"):
+            validate_api_keys(None, None)
+
+    def test_rejects_admin_key_as_standard(self) -> None:
+        with pytest.raises(ValueError, match="not an admin key"):
+            validate_api_keys(ADMIN_KEY, None)
+
+    def test_rejects_non_admin_admin_key(self) -> None:
+        with pytest.raises(ValueError, match="must be an admin API key"):
+            validate_api_keys(STANDARD_KEY, STANDARD_KEY)
+
+    def test_accepts_standard_only(self) -> None:
+        api, admin = validate_api_keys(STANDARD_KEY, None)
+        assert api == STANDARD_KEY
+        assert admin is None
+
+    def test_accepts_standard_and_admin(self) -> None:
+        api, admin = validate_api_keys(STANDARD_KEY, ADMIN_KEY)
+        assert api == STANDARD_KEY
+        assert admin == ADMIN_KEY
+
+
+class TestEnsureAdminHttp:
+    def test_raises_when_unset(self) -> None:
+        with pytest.raises(ValueError, match="CARTESIA_ADMIN_API_KEY"):
+            ensure_admin_http(None)
+
+    def test_returns_client(self) -> None:
+        sentinel = object()
+        assert ensure_admin_http(sentinel) is sentinel
+
+    def test_message_documents_playground(self) -> None:
+        assert "Keys → Admin" in ADMIN_HTTP_REQUIRED_MESSAGE

--- a/uv.lock
+++ b/uv.lock
@@ -150,12 +150,17 @@ wheels = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -164,6 +169,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.7.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "certifi"
@@ -294,6 +302,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "iterators"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +407,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/3b/1599631f59024b75c4d6e3069f4502409970a336647502aaf6b62fb7ac98/multidict-6.4.3-cp313-cp313t-win32.whl", hash = "sha256:0ecdc12ea44bab2807d6b4a7e5eef25109ab1c82a8240d86d3c1fc9f3b72efd5", size = 41775, upload-time = "2025-04-10T22:19:43.707Z" },
     { url = "https://files.pythonhosted.org/packages/e8/4e/09301668d675d02ca8e8e1a3e6be046619e30403f5ada2ed5b080ae28d02/multidict-6.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7146a8742ea71b5d7d955bffcef58a9e6e04efba704b52a460134fefd10a8208", size = 45946, upload-time = "2025-04-10T22:19:45.071Z" },
     { url = "https://files.pythonhosted.org/packages/96/10/7d526c8974f017f1e7ca584c71ee62a638e9334d8d33f27d7cdfc9ae79e4/multidict-6.4.3-py3-none-any.whl", hash = "sha256:59fe01ee8e2a1e8ceb3f6dbb216b09c8d9f4ef1c22c4fc825d045a147fa2ebc9", size = 10400, upload-time = "2025-04-10T22:20:16.445Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -506,6 +541,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-920/cartesia-admin-api-key-in-mcp

## Summary

The MCP server now supports an optional `CARTESIA_ADMIN_API_KEY` for management endpoints that require admin credentials. Standard `CARTESIA_API_KEY` continues to power TTS, STT, voices, and pronunciation tools. Admin and standard keys are validated at startup so they cannot be swapped.

## Changes

- Add `CARTESIA_ADMIN_API_KEY` env var and a dedicated admin HTTP client when set
- Route `get_credit_usage` through the admin client; clear error if the env var is missing
- Reject admin keys in `CARTESIA_API_KEY` and non-admin values in `CARTESIA_ADMIN_API_KEY`
- Document admin key setup and mutual exclusivity in README
- Smoke test skips `get_credit_usage` unless `CARTESIA_ADMIN_API_KEY` is set

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to env parsing, startup validation, and routing one admin tool; no changes to core TTS/STT paths beyond rejecting misconfigured keys.
> 
> **Overview**
> Adds optional **`CARTESIA_ADMIN_API_KEY`** alongside **`CARTESIA_API_KEY`**, with startup validation so admin keys cannot be used as the standard key and vice versa. **`get_credit_usage`** now calls `/usage/credits` through a dedicated admin HTTP client when that env var is set; otherwise the tool fails with a clear message.
> 
> New **`cartesia_mcp/config.py`** centralizes env parsing (`env_or_none`), key validation, and `ensure_admin_http`. **`is_admin_api_key`** in `sdk_setup` detects the `sk_car_admin_` prefix.
> 
> **Testing & CI:** pytest unit tests for config validation, a GitHub Actions workflow on PR/push to `main`, README updates for dual-key setup, and the smoke script skips `get_credit_usage` unless an admin key is configured. Package version bumps to **0.4.0** with a dev pytest dependency group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac148f8713fc44a5c88bce2cfe49358424a55a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->