### PR TITLE
ci: enforce conventional commits for release-please

### DIFF
--- a/.cursor/rules/conventional-commits.mdc
+++ b/.cursor/rules/conventional-commits.mdc
@@ -1,0 +1,33 @@
+---
+description: Conventional Commits for release-please and PyPI releases
+alwaysApply: true
+---
+
+# Conventional Commits (cartesia-mcp)
+
+This repo uses [release-please](https://github.com/googleapis/release-please). **Only conventional commits on `main` drive version bumps and changelog entries.**
+
+## Format
+
+```
+<type>: <short description>
+
+[optional body]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`. Release PRs use `release: 0.x.0`.
+
+Examples:
+
+- `feat: add optional CARTESIA_ADMIN_API_KEY for admin tools`
+- `fix: treat empty admin API key env as unset`
+- `ci: add pytest workflow`
+
+## Pull requests
+
+- **Squash merge:** set the PR title to a conventional commit message (it becomes the commit on `main`).
+- CI checks the PR title and each commit on the branch (`Conventional Commits` workflow).
+
+Non-conventional merges are ignored by release-please (no release PR / no version bump).
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/.github/commitlint.config.mjs
+++ b/.github/commitlint.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('@commitlint/types').UserConfig} */
+export default {
+  extends: ["@commitlint/config-conventional"],
+  ignores: [
+    (message) => message.startsWith("Merge "),
+    (message) => /^release: /i.test(message),
+  ],
+};

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,47 @@
+# Enforces Conventional Commits so release-please can version and open release PRs.
+# Squash merges: use a conventional PR title (becomes the commit on main).
+name: Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  semantic-pr-title:
+    name: PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            release
+          requireScope: false
+
+  commitlint:
+    name: commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .github/commitlint.config.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Commits and releases
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) and [release-please](https://github.com/googleapis/release-please) to bump versions, update `CHANGELOG.md`, and publish to PyPI.
+
+### What to write
+
+Use a type and description in the subject line:
+
+| Type | When |
+|------|------|
+| `feat` | New feature (minor version bump) |
+| `fix` | Bug fix (patch version bump) |
+| `docs` | Documentation only |
+| `ci` | CI / GitHub Actions |
+| `test` | Tests |
+| `chore` | Maintenance (often hidden in changelog) |
+| `release` | Release PRs only (automation) |
+
+Examples:
+
+```
+feat: add optional CARTESIA_ADMIN_API_KEY
+fix: skip blank admin env in smoke test
+```
+
+### Pull requests
+
+1. Open a PR with a **conventional title** (e.g. `feat: …`, `fix: …`).
+2. Prefer **squash merge** so the PR title becomes the single commit on `main`.
+3. Wait for the `Conventional Commits` and `Test` checks.
+4. After merge, release-please opens a `release: x.y.z` PR; merge that to tag and publish.
+
+If commits on `main` are not conventional, release-please will not create a release PR. You can still cut a release manually with a `release: x.y.z` PR that updates `pyproject.toml`, `cartesia_mcp/__init__.py`, `.release-please-manifest.json`, and `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Ask your agent things like:
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.
 
+## Releases
+
+Versions and PyPI publishes are driven by [Conventional Commits](https://www.conventionalcommits.org/) on `main` via release-please. Use PR titles like `feat: …` or `fix: …` (especially when squash merging). See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Testing
 
 Unit tests (no API keys):


### PR DESCRIPTION
## Summary

Release-please only picks up [Conventional Commits](https://www.conventionalcommits.org/) on `main`. PR #27 merged without `feat:`/`fix:` subjects, so the post-merge release-please run logged **0 commits** and did not open a release PR. This adds CI enforcement and contributor docs so future merges drive releases automatically.

## Changes

- **`Conventional Commits` workflow** — validates PR titles (`amannn/action-semantic-pull-request`) and branch commits (`commitlint`); allows `release:` for release PRs
- **`CONTRIBUTING.md`** — commit types, squash-merge guidance, release flow
- **`.cursor/rules/conventional-commits.mdc`** — reminds agents to use conventional PR titles/commits in this repo
- **`README.md`** — short Releases section linking to CONTRIBUTING

## Test plan

- [ ] Merge this PR; open a follow-up with title `feat: …` and confirm checks pass
- [ ] Intentionally bad PR title should fail the semantic PR check

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub Actions only; no runtime, auth, or package code changes.
> 
> **Overview**
> Adds **CI and contributor guidance** so merges on `main` use [Conventional Commits](https://www.conventionalcommits.org/) and **release-please** can open release PRs and publish to PyPI (addressing cases where non-conventional squash titles produced zero releasable commits).
> 
> A new **`Conventional Commits`** workflow validates **PR titles** (`action-semantic-pull-request`) and **branch commits** (`commitlint` via `.github/commitlint.config.mjs`, with ignores for merge commits and `release:` messages). **`CONTRIBUTING.md`** documents commit types, squash-merge practice, and the release flow; **README** gains a short Releases section. **`.cursor/rules/conventional-commits.mdc`** reminds agents to use conventional PR titles in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250d338fe3f0311d2ee03152c5c4c0746047b453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->