### PR TITLE
feat: Cartesia/mcp User-Agent for API attribution

### DIFF
--- a/cartesia_mcp/client_headers.py
+++ b/cartesia_mcp/client_headers.py
@@ -1,0 +1,24 @@
+"""Outbound API request attribution for cartesia-mcp."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+CLIENT_NAME = "cartesia-mcp"
+
+
+def get_package_version() -> str:
+    try:
+        return version("cartesia-mcp")
+    except PackageNotFoundError:
+        return "0.0.0.dev"
+
+
+def client_request_headers() -> dict[str, str]:
+    """Headers attached to every Cartesia API call from this MCP server."""
+    ver = get_package_version()
+    return {
+        "X-Cartesia-Client": CLIENT_NAME,
+        "X-Cartesia-Client-Version": ver,
+        "User-Agent": f"{CLIENT_NAME}/{ver}",
+    }

--- a/cartesia_mcp/client_headers.py
+++ b/cartesia_mcp/client_headers.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-CLIENT_NAME = "cartesia-mcp"
+# Matches cartesia-python (Cartesia/Python) and cartesia-js (Cartesia/JS).
+USER_AGENT_PREFIX = "Cartesia/mcp"
 
 
 def get_package_version() -> str:
@@ -14,11 +15,10 @@ def get_package_version() -> str:
         return "0.0.0.dev"
 
 
+def user_agent() -> str:
+    return f"{USER_AGENT_PREFIX} {get_package_version()}"
+
+
 def client_request_headers() -> dict[str, str]:
     """Headers attached to every Cartesia API call from this MCP server."""
-    ver = get_package_version()
-    return {
-        "X-Cartesia-Client": CLIENT_NAME,
-        "X-Cartesia-Client-Version": ver,
-        "User-Agent": f"{CLIENT_NAME}/{ver}",
-    }
+    return {"User-Agent": user_agent()}

--- a/cartesia_mcp/sdk_setup.py
+++ b/cartesia_mcp/sdk_setup.py
@@ -6,6 +6,7 @@ from cartesia import Cartesia
 from cartesia.core.http_client import HttpClient
 
 from cartesia_mcp.api_version import CARTESIA_VERSION
+from cartesia_mcp.client_headers import client_request_headers
 
 # Admin keys use sk_car_admin_<id>.<secret>; standard keys use sk_car_<id>.<secret>.
 ADMIN_API_KEY_PREFIX = "sk_car_admin_"
@@ -31,6 +32,7 @@ def _apply_api_version(wrapper) -> None:
     def get_headers() -> dict[str, str]:
         headers = original_get_headers()
         headers["Cartesia-Version"] = CARTESIA_VERSION
+        headers.update(client_request_headers())
         return headers
 
     wrapper.get_headers = get_headers

--- a/tests/test_client_headers.py
+++ b/tests/test_client_headers.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-from cartesia_mcp.client_headers import CLIENT_NAME, client_request_headers, get_package_version
+from cartesia_mcp.client_headers import USER_AGENT_PREFIX, client_request_headers, user_agent
 
 
-def test_get_package_version_is_non_empty() -> None:
-    assert get_package_version()
+def test_user_agent_format() -> None:
+    ua = user_agent()
+    assert ua.startswith(f"{USER_AGENT_PREFIX} ")
+    assert len(ua.split()) >= 2
 
 
 def test_client_request_headers() -> None:
     headers = client_request_headers()
-    ver = get_package_version()
-
-    assert headers["X-Cartesia-Client"] == CLIENT_NAME
-    assert headers["X-Cartesia-Client-Version"] == ver
-    assert headers["User-Agent"] == f"{CLIENT_NAME}/{ver}"
+    assert headers == {"User-Agent": user_agent()}

--- a/tests/test_client_headers.py
+++ b/tests/test_client_headers.py
@@ -1,0 +1,18 @@
+"""Tests for outbound client attribution headers."""
+
+from __future__ import annotations
+
+from cartesia_mcp.client_headers import CLIENT_NAME, client_request_headers, get_package_version
+
+
+def test_get_package_version_is_non_empty() -> None:
+    assert get_package_version()
+
+
+def test_client_request_headers() -> None:
+    headers = client_request_headers()
+    ver = get_package_version()
+
+    assert headers["X-Cartesia-Client"] == CLIENT_NAME
+    assert headers["X-Cartesia-Client-Version"] == ver
+    assert headers["User-Agent"] == f"{CLIENT_NAME}/{ver}"

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from cartesia_mcp.api_version import CARTESIA_VERSION
-from cartesia_mcp.client_headers import CLIENT_NAME, client_request_headers
+from cartesia_mcp.client_headers import user_agent
 from cartesia_mcp.sdk_setup import _apply_api_version
 
 
-def test_apply_api_version_adds_mcp_client_headers() -> None:
+def test_apply_api_version_sets_mcp_user_agent() -> None:
     wrapper = MagicMock()
     wrapper.get_headers.return_value = {
         "X-Fern-Language": "Python",
@@ -21,10 +21,6 @@ def test_apply_api_version_adds_mcp_client_headers() -> None:
     _apply_api_version(wrapper)
 
     headers = wrapper.get_headers()
-    expected = client_request_headers()
-
     assert headers["Cartesia-Version"] == CARTESIA_VERSION
-    assert headers["X-Cartesia-Client"] == CLIENT_NAME
-    assert headers["X-Cartesia-Client-Version"] == expected["X-Cartesia-Client-Version"]
-    assert headers["User-Agent"] == expected["User-Agent"]
+    assert headers["User-Agent"] == user_agent()
     assert wrapper.httpx_client.base_headers == wrapper.get_headers

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -1,0 +1,30 @@
+"""Tests for Cartesia client header wiring in sdk_setup."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from cartesia_mcp.api_version import CARTESIA_VERSION
+from cartesia_mcp.client_headers import CLIENT_NAME, client_request_headers
+from cartesia_mcp.sdk_setup import _apply_api_version
+
+
+def test_apply_api_version_adds_mcp_client_headers() -> None:
+    wrapper = MagicMock()
+    wrapper.get_headers.return_value = {
+        "X-Fern-Language": "Python",
+        "X-Fern-SDK-Name": "cartesia",
+        "X-Fern-SDK-Version": "2.0.17",
+    }
+    wrapper.httpx_client = MagicMock()
+
+    _apply_api_version(wrapper)
+
+    headers = wrapper.get_headers()
+    expected = client_request_headers()
+
+    assert headers["Cartesia-Version"] == CARTESIA_VERSION
+    assert headers["X-Cartesia-Client"] == CLIENT_NAME
+    assert headers["X-Cartesia-Client-Version"] == expected["X-Cartesia-Client-Version"]
+    assert headers["User-Agent"] == expected["User-Agent"]
+    assert wrapper.httpx_client.base_headers == wrapper.get_headers


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-944/mcp-attribute-api-requests-with-client-source-and-cartesia-mcp-version

## Summary

`cartesia-mcp` sets `User-Agent: Cartesia/mcp <version>` on outbound API calls, matching the v3 SDK pattern (`Cartesia/Python`, `Cartesia/JS`). **No bifrost change required** — Datadog APM already indexes `@http.useragent` on traces.

## How to measure MCP users in Datadog (after release)

APM trace query (same pattern as Python SDK):

```text
@http.useragent:"Cartesia/mcp*"
```

Example (adjust `service` / time range):

```text
@http.useragent:"Cartesia/mcp*" service:api
```

Count distinct orgs by combining with actor fields already on authed traces/logs (e.g. `user_id` / `actor_id` from auth context).

## Client identification (context)

| Source | User-Agent / headers | Visible in DDog APM `@http.useragent`? |
| --- | --- | --- |
| **cartesia-mcp** (this PR) | `Cartesia/mcp <version>` | Yes, after PyPI release |
| **cartesia-python** v3 | `Cartesia/Python <version>` | Yes (already works) |
| **cartesia-js** v3 | `Cartesia/JS <version>` | Yes |
| **curl / custom** | arbitrary or missing | Sometimes |

Underlying Fern v2 httpx client inside MCP is overridden by this `User-Agent` on API calls.

## Changes

- Add `cartesia_mcp/client_headers.py` for `User-Agent: Cartesia/mcp <version>`
- Wire through `sdk_setup.py` on all SDK and `extra_api` requests
- Unit tests

## Test plan

- [x] `uv run pytest tests/ -q`