### PR TITLE
docs: README MCP setup aligned with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [
 - A **[Cartesia API key](https://play.cartesia.ai/keys)** for TTS, STT, voices, and related APIs
 - Optionally, an **[admin API key](https://play.cartesia.ai/keys)** (Keys → Admin) for management tools such as `get_credit_usage`. Admin keys and standard keys are separate credentials; each only works on its own route class.
 
-## Setup
+## Quick install
 
-Add this to your MCP config with your standard API key.
+1. Get an API key from [play.cartesia.ai/keys](https://play.cartesia.ai/keys).
+2. **Cursor (one click):** [Add Cartesia MCP to Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXSwiZW52Ijp7IkNBUlRFU0lBX0FQSV9LRVkiOiIke2VudjpDQVJURVNJQV9BUElfS0VZfSJ9fQ==) — then set `CARTESIA_API_KEY` when prompted.
+3. **Other agents:** `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp` ([add-mcp](https://www.npmjs.com/package/add-mcp); use `--env "CARTESIA_API_KEY=..."` or follow prompts).
+4. Restart the client and confirm **cartesia-mcp** is connected.
+
+See [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp) for details.
+
+## Manual setup
 
 **Cursor** — `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` globally.
 
@@ -34,8 +41,6 @@ Add this to your MCP config with your standard API key.
   }
 }
 ```
-
-Restart the client (or refresh MCP in Cursor) and confirm **cartesia-mcp** is connected.
 
 ## Try it
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [
 
 ## Setup
 
-Get an [API key](https://play.cartesia.ai/keys), then:
+Get an [API key](https://play.cartesia.ai/keys). Full instructions: [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp).
 
-**Cursor** — [Install Cartesia MCP](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXX0=). In **Settings → MCP**, set `CARTESIA_API_KEY` on **cartesia-mcp**.
+**CLI (recommended)** — `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp --env 'CARTESIA_API_KEY=${CARTESIA_API_KEY}'`
 
-**CLI** — `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp --env 'CARTESIA_API_KEY=${CARTESIA_API_KEY}'` (prompts for your API key; add `-a cursor` to target Cursor).
+**Cursor** — [Install Cartesia MCP](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXX0=), then set `CARTESIA_API_KEY` in **Settings → MCP**.
 
-Full instructions: [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp).
+**Claude Code** — `claude mcp add -e CARTESIA_API_KEY=<your-api-key> cartesia-mcp -- uvx cartesia-mcp`
 
 ## Manual setup
 
-Add to `.cursor/mcp.json`, Claude Desktop’s `claude_desktop_config.json`, or your client’s MCP config:
+Add to `.cursor/mcp.json`, `.mcp.json` (Claude Code), or your client’s MCP config:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -13,20 +13,19 @@ The Cartesia MCP server exposes [Cartesia](https://cartesia.ai/) APIs over the [
 - A **[Cartesia API key](https://play.cartesia.ai/keys)** for TTS, STT, voices, and related APIs
 - Optionally, an **[admin API key](https://play.cartesia.ai/keys)** (Keys → Admin) for management tools such as `get_credit_usage`. Admin keys and standard keys are separate credentials; each only works on its own route class.
 
-## Quick install
+## Setup
 
-1. Get an API key from [play.cartesia.ai/keys](https://play.cartesia.ai/keys).
-2. **Cursor (one click):** [Add Cartesia MCP to Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXSwiZW52Ijp7IkNBUlRFU0lBX0FQSV9LRVkiOiIke2VudjpDQVJURVNJQV9BUElfS0VZfSJ9fQ==) — then set `CARTESIA_API_KEY` when prompted.
-3. **Other agents:** `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp` ([add-mcp](https://www.npmjs.com/package/add-mcp); use `--env "CARTESIA_API_KEY=..."` or follow prompts).
-4. Restart the client and confirm **cartesia-mcp** is connected.
+Get an [API key](https://play.cartesia.ai/keys), then:
 
-See [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp) for details.
+**Cursor** — [Install Cartesia MCP](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXX0=). In **Settings → MCP**, set `CARTESIA_API_KEY` on **cartesia-mcp**.
+
+**CLI** — `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp` ([add-mcp](https://www.npmjs.com/package/add-mcp) detects your client and prompts for your API key).
+
+Full instructions: [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp).
 
 ## Manual setup
 
-**Cursor** — `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` globally.
-
-**Claude Desktop** — **Settings → Developer → Edit Config** (`claude_desktop_config.json`).
+Add to `.cursor/mcp.json`, Claude Desktop’s `claude_desktop_config.json`, or your client’s MCP config:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Get an [API key](https://play.cartesia.ai/keys), then:
 
 **Cursor** — [Install Cartesia MCP](cursor://anysphere.cursor-deeplink/mcp/install?name=cartesia-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJjYXJ0ZXNpYS1tY3AiXX0=). In **Settings → MCP**, set `CARTESIA_API_KEY` on **cartesia-mcp**.
 
-**CLI** — `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp` ([add-mcp](https://www.npmjs.com/package/add-mcp) detects your client and prompts for your API key).
+**CLI** — `npx add-mcp "uvx cartesia-mcp" --name cartesia-mcp --env 'CARTESIA_API_KEY=${CARTESIA_API_KEY}'` (prompts for your API key; add `-a cursor` to target Cursor).
 
 Full instructions: [Cartesia docs — MCP](https://docs.cartesia.ai/tools/ai/mcp).
 


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-944/mcp-attribute-api-requests-with-client-source-and-cartesia-mcp-version

## Summary

Aligns the README setup section with the Cartesia docs MCP page: `add-mcp` first, then Cursor and Claude Code, with Cursor-only manual JSON. Points readers to the docs for full instructions.

## Changes

- **Setup** lists CLI (`add-mcp` with `--env`), Cursor deeplink + Settings → MCP, and `claude mcp add`
- **Manual setup (Cursor)** only — `.cursor/mcp.json` with `YOUR_API_KEY`
- Intro clients updated (Claude Code, Codex; not Claude Desktop)