### PR TITLE
feat: stream speech_to_text over STT WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Ask your agent things like:
 | Tool | Description |
 |------|-------------|
 | `text_to_speech` | Convert text to audio; optional speed, volume, emotion, and pronunciation dict |
-| `speech_to_text` | Batch-transcribe an audio file (`ink-whisper`) |
+| `speech_to_text` | Stream-transcribe an audio file via STT WebSocket (`ink-2`) |
 | `list_voices` | List available voices (filter by language, search, gender, etc.) |
 | `get_voice` | Fetch metadata for a voice by ID |
 | `clone_voice` | Clone a voice from an audio sample |

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -33,6 +33,7 @@ from cartesia_mcp.sdk_setup import create_cartesia_client, get_http
 from cartesia_mcp.utils import (
     build_list_voices_request_options,
     create_output_file,
+    iter_stt_audio_chunks,
     pronunciation_dict_list_to_result,
     voice_list_page_to_result,
 )
@@ -425,11 +426,11 @@ def list_voices(
 
 
 @mcp.tool(description="""
-        Transcribe a pre-recorded audio file to text using Cartesia batch STT (`POST /stt`).
+        Stream-transcribe a pre-recorded audio file using Cartesia STT WebSocket (`/stt/websocket`).
 
-        **Pricing:** 1 credit per 2 seconds of audio.
+        **Pricing:** See [STT pricing](https://docs.cartesia.ai/pricing#speech-to-text) for model-specific rates.
 
-        **Supported file formats:** flac, m4a, mp3, mp4, mpeg, mpga, oga, ogg, wav, webm
+        **Supported inputs:** mono PCM WAV, or raw PCM with `encoding` and `sample_rate`.
 
         Parameters
         ----------
@@ -437,7 +438,7 @@ def list_voices(
             Absolute path to the audio file.
 
         model : str
-            STT model ID (default `ink-whisper`).
+            STT model ID (default `ink-2`).
 
         language : typing.Optional[str]
             ISO-639-1 language code (defaults to `en`).
@@ -449,35 +450,65 @@ def list_voices(
             Sample rate in Hz when `encoding` is set.
 
         timestamp_granularities : typing.Optional[typing.Sequence[TimestampGranularity]]
-            Pass `["word"]` for word-level timestamps.
+            Pass `["word"]` for word-level timestamps when returned by the stream.
 
         request_options : typing.Optional[RequestOptions]
-            Request-specific configuration.
+            Unused for streaming STT; kept for backward compatibility.
         """)
 def speech_to_text(
     file_path: str,
-    model: str = "ink-whisper",
+    model: str = "ink-2",
     language: typing.Optional[str] = None,
     encoding: typing.Optional[SttEncoding] = None,
     sample_rate: typing.Optional[int] = None,
     timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> TranscriptionResponse:
-    with open(file_path, "rb") as audio_file:
-        kwargs: dict[str, typing.Any] = {
-            "file": audio_file,
-            "model": model,
-            "request_options": request_options,
-        }
-        if language is not None:
-            kwargs["language"] = language
-        if encoding is not None:
-            kwargs["encoding"] = encoding
-        if sample_rate is not None:
-            kwargs["sample_rate"] = sample_rate
-        if timestamp_granularities is not None:
-            kwargs["timestamp_granularities"] = list(timestamp_granularities)
-        return client.stt.transcribe(**kwargs)
+    _ = request_options
+    stream_encoding, stream_sample_rate, chunks = iter_stt_audio_chunks(
+        file_path,
+        encoding=encoding,
+        sample_rate=sample_rate,
+    )
+    stt_language = language if language is not None else "en"
+    full_text = ""
+    duration: typing.Optional[float] = None
+    response_language: typing.Optional[str] = stt_language
+    words: typing.Optional[typing.List[typing.Any]] = None
+
+    for result in client.stt.websocket(
+        model=model,
+        language=stt_language,
+        encoding=stream_encoding,
+        sample_rate=stream_sample_rate,
+    ).transcribe(
+        chunks,
+        model=model,
+        language=stt_language,
+        encoding=stream_encoding,
+        sample_rate=stream_sample_rate,
+    ):
+        if result.get("type") != "transcript":
+            continue
+        if result.get("is_final"):
+            full_text += result.get("text", "")
+            if (
+                timestamp_granularities
+                and "word" in timestamp_granularities
+                and "words" in result
+            ):
+                words = result["words"]
+        if "duration" in result:
+            duration = result["duration"]
+        if "language" in result:
+            response_language = result["language"]
+
+    return TranscriptionResponse(
+        text=full_text,
+        language=response_language,
+        duration=duration,
+        words=words,
+    )
 
 
 @mcp.tool(description="""

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -1,7 +1,10 @@
 import os
 import datetime
 import typing
+import wave
 from pathlib import Path
+
+from cartesia.stt.types.stt_encoding import SttEncoding
 from cartesia_mcp.custom_types import (
     ListPronunciationDictsResult,
     ListVoicesResult,
@@ -11,6 +14,82 @@ from cartesia.core.pagination import SyncPager
 from cartesia.core.request_options import RequestOptions
 from cartesia.voice_changer.types import OutputFormatContainer
 from cartesia.voices.types import Voice
+
+_BYTES_PER_SAMPLE: dict[SttEncoding, int] = {
+    "pcm_s16le": 2,
+    "pcm_s32le": 4,
+    "pcm_f16le": 2,
+    "pcm_f32le": 4,
+    "pcm_mulaw": 1,
+    "pcm_alaw": 1,
+}
+
+
+def _wav_encoding(sample_width: int) -> SttEncoding:
+    if sample_width == 2:
+        return "pcm_s16le"
+    if sample_width == 4:
+        return "pcm_s32le"
+    raise ValueError(
+        f"Unsupported WAV sample width {sample_width} bytes (expected 2 or 4)."
+    )
+
+
+def _read_pcm_chunks(file_path: str, *, encoding: SttEncoding, sample_rate: int) -> typing.Iterator[bytes]:
+    bytes_per_sample = _BYTES_PER_SAMPLE[encoding]
+    chunk_bytes = max(sample_rate * bytes_per_sample // 10, 1)
+
+    def _iter() -> typing.Iterator[bytes]:
+        with open(file_path, "rb") as audio_file:
+            while chunk := audio_file.read(chunk_bytes):
+                yield chunk
+
+    return _iter()
+
+
+def _read_wav_chunks(file_path: str) -> tuple[SttEncoding, int, typing.Iterator[bytes]]:
+    with wave.open(file_path, "rb") as wf:
+        if wf.getnchannels() != 1:
+            raise ValueError(f"WAV must be mono, got {wf.getnchannels()} channels.")
+        if wf.getcomptype() != "NONE":
+            raise ValueError(f"WAV must be uncompressed PCM, got {wf.getcomptype()!r}.")
+        encoding = _wav_encoding(wf.getsampwidth())
+        sample_rate = wf.getframerate()
+        frames_per_chunk = max(sample_rate // 10, 1)
+
+        def _iter() -> typing.Iterator[bytes]:
+            with wave.open(file_path, "rb") as reader:
+                while True:
+                    data = reader.readframes(frames_per_chunk)
+                    if not data:
+                        break
+                    yield data
+
+        return encoding, sample_rate, _iter()
+
+
+def iter_stt_audio_chunks(
+    file_path: str,
+    *,
+    encoding: typing.Optional[SttEncoding] = None,
+    sample_rate: typing.Optional[int] = None,
+) -> tuple[SttEncoding, int, typing.Iterator[bytes]]:
+    """Prepare PCM chunks for STT WebSocket streaming."""
+    path = Path(file_path)
+    if path.suffix.lower() == ".wav":
+        return _read_wav_chunks(file_path)
+
+    if encoding is not None and sample_rate is not None:
+        if encoding not in _BYTES_PER_SAMPLE:
+            raise ValueError(f"Unsupported encoding {encoding!r}.")
+        return encoding, sample_rate, _read_pcm_chunks(
+            file_path, encoding=encoding, sample_rate=sample_rate
+        )
+
+    raise ValueError(
+        "Streaming STT requires a mono PCM WAV file, or raw PCM with encoding and sample_rate set."
+    )
+
 
 def create_output_file(output_directory: str, tool_type: ToolType,
                        extension: OutputFormatContainer) -> Path:


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1221/make-mcp-speech-to-text-streaming-instead-of-batched

## Summary

Switches the MCP `speech_to_text` tool from batch `POST /stt` to realtime `/stt/websocket` streaming with `ink-2`, matching the docs update in cartesia-ai/docs.

## Changes

- Stream mono PCM WAV or raw PCM files over the STT WebSocket API.
- Default STT model to `ink-2`.
- Update README tool table and tool docstring.

## Test plan

- [ ] `uv run python scripts/test_all_tools.py` with `CARTESIA_API_KEY` set
- [ ] Transcribe a mono WAV from `text_to_speech` output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the STT integration and default model; supported file inputs are stricter than the previous batch API, which may break callers transcribing non-WAV containers without conversion.
> 
> **Overview**
> Replaces batch **`POST /stt`** transcription with **STT WebSocket** streaming for the MCP `speech_to_text` tool, defaulting the model to **`ink-2`** instead of `ink-whisper`.
> 
> Audio is prepared via new **`iter_stt_audio_chunks`** in `utils.py`: **mono PCM WAV** (encoding/sample rate from the header) or **raw PCM** when `encoding` and `sample_rate` are set, read in ~100ms chunks and sent through `client.stt.websocket().transcribe()`. Final transcript text, duration, language, and optional word timestamps are assembled from stream `transcript` events into the same **`TranscriptionResponse`** shape. **`request_options`** is ignored for streaming but left on the tool for compatibility.
> 
> Docs now describe WebSocket streaming, model-specific pricing, and the narrower input rules (no longer advertising broad container formats like MP3/FLAC for this path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa0896f0d365028d09810c4b1e6d5c5f4c7bad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->