### PR TITLE
feat: add batch and stream modes to speech_to_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Ask your agent things like:
 | Tool | Description |
 |------|-------------|
 | `text_to_speech` | Convert text to audio; optional speed, volume, emotion, and pronunciation dict |
-| `speech_to_text` | Stream-transcribe an audio file via STT WebSocket (`ink-2`) |
+| `speech_to_text` | Transcribe an audio file (`mode=batch` default, or `mode=stream`) |
 | `list_voices` | List available voices (filter by language, search, gender, etc.) |
 | `get_voice` | Fetch metadata for a voice by ID |
 | `clone_voice` | Clone a voice from an audio sample |
@@ -111,7 +111,7 @@ By default, generated audio is written to the server's working directory. To cho
 
 ### Local audio files
 
-Tools like `speech_to_text` and `voice_change` need paths to existing audio files on disk. Pass the full path to each file when prompting your agent.
+Tools like `speech_to_text` and `voice_change` need paths to existing audio files on disk. Pass the full path to each file when prompting your agent. For `speech_to_text`, use the default batch mode for common containers (mp3, flac, wav, etc.). Use `mode="stream"` for mono PCM WAV or raw PCM with `encoding` and `sample_rate`.
 
 ### Admin API key
 

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -425,46 +425,53 @@ def list_voices(
     return voice_list_page_to_result(pager)
 
 
-@mcp.tool(description="""
-        Stream-transcribe a pre-recorded audio file using Cartesia STT WebSocket (`/stt/websocket`).
+DEFAULT_STT_BATCH_MODEL = "ink-whisper"
+DEFAULT_STT_STREAM_MODEL = "ink-2"
+SttMode = typing.Literal["batch", "stream"]
 
-        **Pricing:** See [STT pricing](https://docs.cartesia.ai/pricing#speech-to-text) for model-specific rates.
 
-        **Supported inputs:** mono PCM WAV, or raw PCM with `encoding` and `sample_rate`.
+def _resolve_stt_model(mode: SttMode, model: typing.Optional[str]) -> str:
+    if model is not None:
+        return model
+    return DEFAULT_STT_BATCH_MODEL if mode == "batch" else DEFAULT_STT_STREAM_MODEL
 
-        Parameters
-        ----------
-        file_path : str
-            Absolute path to the audio file.
 
-        model : str
-            STT model ID (default `ink-2`).
-
-        language : typing.Optional[str]
-            ISO-639-1 language code (defaults to `en`).
-
-        encoding : typing.Optional[SttEncoding]
-            Required for raw PCM without a container header.
-
-        sample_rate : typing.Optional[int]
-            Sample rate in Hz when `encoding` is set.
-
-        timestamp_granularities : typing.Optional[typing.Sequence[TimestampGranularity]]
-            Pass `["word"]` for word-level timestamps when returned by the stream.
-
-        request_options : typing.Optional[RequestOptions]
-            Unused for streaming STT; kept for backward compatibility.
-        """)
-def speech_to_text(
+def _speech_to_text_batch(
+    *,
     file_path: str,
-    model: str = "ink-2",
-    language: typing.Optional[str] = None,
-    encoding: typing.Optional[SttEncoding] = None,
-    sample_rate: typing.Optional[int] = None,
-    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]] = None,
-    request_options: typing.Optional[RequestOptions] = None,
+    model: str,
+    language: typing.Optional[str],
+    encoding: typing.Optional[SttEncoding],
+    sample_rate: typing.Optional[int],
+    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]],
+    request_options: typing.Optional[RequestOptions],
 ) -> TranscriptionResponse:
-    _ = request_options
+    with open(file_path, "rb") as audio_file:
+        kwargs: dict[str, typing.Any] = {
+            "file": audio_file,
+            "model": model,
+            "request_options": request_options,
+        }
+        if language is not None:
+            kwargs["language"] = language
+        if encoding is not None:
+            kwargs["encoding"] = encoding
+        if sample_rate is not None:
+            kwargs["sample_rate"] = sample_rate
+        if timestamp_granularities is not None:
+            kwargs["timestamp_granularities"] = list(timestamp_granularities)
+        return client.stt.transcribe(**kwargs)
+
+
+def _speech_to_text_stream(
+    *,
+    file_path: str,
+    model: str,
+    language: typing.Optional[str],
+    encoding: typing.Optional[SttEncoding],
+    sample_rate: typing.Optional[int],
+    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]],
+) -> TranscriptionResponse:
     stream_encoding, stream_sample_rate, chunks = iter_stt_audio_chunks(
         file_path,
         encoding=encoding,
@@ -508,6 +515,77 @@ def speech_to_text(
         language=response_language,
         duration=duration,
         words=words,
+    )
+
+
+@mcp.tool(description="""
+        Transcribe a pre-recorded audio file to text.
+
+        **Default (`mode="batch"`):** upload the file via batch STT (`POST /stt`).
+        Best for typical MCP file-on-disk tasks (mp3, flac, wav, and other containers).
+        Default model: `ink-whisper`.
+
+        **Streaming (`mode="stream"`):** send mono PCM over STT WebSocket (`/stt/websocket`).
+        Use for mono PCM WAV (for example TTS output) or raw PCM with `encoding` and
+        `sample_rate`. Default model: `ink-2`.
+
+        **Pricing:** See [STT pricing](https://docs.cartesia.ai/pricing#speech-to-text).
+
+        Parameters
+        ----------
+        file_path : str
+            Absolute path to the audio file.
+
+        mode : str
+            `batch` (default) or `stream`.
+
+        model : typing.Optional[str]
+            STT model ID. Defaults to `ink-whisper` for batch and `ink-2` for stream.
+
+        language : typing.Optional[str]
+            ISO-639-1 language code (defaults to `en` for stream; batch uses API default).
+
+        encoding : typing.Optional[SttEncoding]
+            Required for raw PCM without a container header (both modes).
+
+        sample_rate : typing.Optional[int]
+            Sample rate in Hz when `encoding` is set.
+
+        timestamp_granularities : typing.Optional[typing.Sequence[TimestampGranularity]]
+            Pass `["word"]` for word-level timestamps when supported.
+
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration (batch mode only).
+        """)
+def speech_to_text(
+    file_path: str,
+    mode: SttMode = "batch",
+    model: typing.Optional[str] = None,
+    language: typing.Optional[str] = None,
+    encoding: typing.Optional[SttEncoding] = None,
+    sample_rate: typing.Optional[int] = None,
+    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]] = None,
+    request_options: typing.Optional[RequestOptions] = None,
+) -> TranscriptionResponse:
+    stt_model = _resolve_stt_model(mode, model)
+    if mode == "stream":
+        _ = request_options
+        return _speech_to_text_stream(
+            file_path=file_path,
+            model=stt_model,
+            language=language,
+            encoding=encoding,
+            sample_rate=sample_rate,
+            timestamp_granularities=timestamp_granularities,
+        )
+    return _speech_to_text_batch(
+        file_path=file_path,
+        model=stt_model,
+        language=language,
+        encoding=encoding,
+        sample_rate=sample_rate,
+        timestamp_granularities=timestamp_granularities,
+        request_options=request_options,
     )
 
 

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -153,7 +153,7 @@ def main() -> int:
 
     if tts_path and os.path.isfile(tts_path):
         stt_result = run(
-            "speech_to_text",
+            "speech_to_text(batch)",
             lambda: s.speech_to_text(file_path=tts_path, language="en"),
         )
         if stt_result is not None:
@@ -161,8 +161,24 @@ def main() -> int:
                 stt_result.get("text") if isinstance(stt_result, dict) else None
             )
             if not text:
-                failures.append("speech_to_text(empty)")
-                print("  FAIL speech_to_text: empty transcript")
+                failures.append("speech_to_text(batch)(empty)")
+                print("  FAIL speech_to_text(batch): empty transcript")
+
+        stream_result = run(
+            "speech_to_text(stream)",
+            lambda: s.speech_to_text(
+                file_path=tts_path,
+                mode="stream",
+                language="en",
+            ),
+        )
+        if stream_result is not None:
+            stream_text = getattr(stream_result, "text", None) or (
+                stream_result.get("text") if isinstance(stream_result, dict) else None
+            )
+            if not stream_text:
+                failures.append("speech_to_text(stream)(empty)")
+                print("  FAIL speech_to_text(stream): empty transcript")
 
     if s.admin_http is not None:
         run("get_credit_usage", lambda: s.get_credit_usage())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest setup shared across the test suite."""
+
+from __future__ import annotations
+
+import os
+
+# server.py validates keys at import time; unit tests mock HTTP clients instead.
+os.environ.setdefault(
+    "CARTESIA_API_KEY",
+    "sk_car_testId1234567890ab.secretPartHere1234567890abcdefghij",
+)

--- a/tests/test_speech_to_text_modes.py
+++ b/tests/test_speech_to_text_modes.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, mock_open, patch
+
+import cartesia_mcp.server as server
+
+
+def test_resolve_stt_model_defaults() -> None:
+    assert server._resolve_stt_model("batch", None) == "ink-whisper"
+    assert server._resolve_stt_model("stream", None) == "ink-2"
+
+
+def test_resolve_stt_model_override() -> None:
+    assert server._resolve_stt_model("batch", "ink-2") == "ink-2"
+
+
+@patch("cartesia_mcp.server.client")
+def test_speech_to_text_batch_uses_transcribe(mock_client: MagicMock) -> None:
+    mock_client.stt.transcribe.return_value = {"text": "hello"}
+
+    with patch("builtins.open", mock_open(read_data=b"audio")):
+        result = server.speech_to_text("/tmp/sample.mp3", mode="batch", language="en")
+
+    assert result == {"text": "hello"}
+    mock_client.stt.transcribe.assert_called_once()
+    kwargs = mock_client.stt.transcribe.call_args.kwargs
+    assert kwargs["model"] == "ink-whisper"
+    assert kwargs["language"] == "en"
+
+
+@patch("cartesia_mcp.server.client")
+@patch("cartesia_mcp.server.iter_stt_audio_chunks")
+def test_speech_to_text_stream_uses_websocket(
+    mock_iter_chunks: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    mock_iter_chunks.return_value = ("pcm_s16le", 44100, iter([b"chunk"]))
+    mock_ws = MagicMock()
+    mock_client.stt.websocket.return_value = mock_ws
+    mock_ws.transcribe.return_value = [
+        {"type": "transcript", "is_final": True, "text": "hello world"},
+    ]
+
+    result = server.speech_to_text("/tmp/sample.wav", mode="stream")
+
+    assert result.text == "hello world"
+    mock_client.stt.websocket.assert_called_once()
+    mock_ws.transcribe.assert_called_once()


### PR DESCRIPTION
## Summary

Restores batch STT for typical MCP file transcription while keeping WebSocket streaming available. `speech_to_text` now defaults to `mode="batch"` (`ink-whisper`, broad container support) and supports `mode="stream"` for mono PCM WAV / raw PCM workflows (`ink-2`).

Follow-up to the streaming-only change in v0.7.0.

## Changes

- Add `mode` parameter (`batch` | `stream`, default `batch`) to `speech_to_text`
- Restore `POST /stt` batch path with optional model override
- Keep WebSocket streaming path behind `mode="stream"`
- Unit tests for mode routing; smoke script exercises both modes
- README updates for mode selection guidance

## Test plan

- [x] `uv run pytest`
- [ ] `uv run python scripts/test_all_tools.py` with `CARTESIA_API_KEY`

Made with [Cursor](https://cursor.com)