### PR TITLE
feat: upgrade cartesia-mcp to cartesia-python v3

### DIFF
--- a/cartesia_mcp/client_headers.py
+++ b/cartesia_mcp/client_headers.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-# Matches cartesia-python (Cartesia/Python) and cartesia-js (Cartesia/JS).
-USER_AGENT_PREFIX = "Cartesia/mcp"
+CLIENT_ID = "cartesia-mcp"
 
 
 def get_package_version() -> str:
@@ -15,10 +14,14 @@ def get_package_version() -> str:
         return "0.0.0.dev"
 
 
-def user_agent() -> str:
-    return f"{USER_AGENT_PREFIX} {get_package_version()}"
+def client_header() -> str:
+    return f"{CLIENT_ID}/{get_package_version()}"
 
 
 def client_request_headers() -> dict[str, str]:
     """Headers attached to every Cartesia API call from this MCP server."""
-    return {"User-Agent": user_agent()}
+    header = client_header()
+    return {
+        "User-Agent": header,
+        "X-Cartesia-Client": header,
+    }

--- a/cartesia_mcp/config.py
+++ b/cartesia_mcp/config.py
@@ -46,7 +46,7 @@ def validate_api_keys(
     return api_key, admin_api_key
 
 
-def ensure_admin_http(admin_http: typing.Any) -> typing.Any:
-    if admin_http is None:
+def ensure_admin_client(admin_client: typing.Any) -> typing.Any:
+    if admin_client is None:
         raise ValueError(ADMIN_HTTP_REQUIRED_MESSAGE)
-    return admin_http
+    return admin_client

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -1,11 +1,7 @@
 """
-HTTP helpers for Cartesia endpoints not generated on the Fern v2 Python SDK.
+HTTP helpers for Cartesia endpoints not generated on the Python SDK.
 
-The pinned `cartesia` 2.x client exposes tts, stt, voices, and voice_changer
-only — not pronunciation dictionaries or usage/credits. These thin wrappers call the
-same httpx stack as the SDK (shared auth, base URL, and Cartesia-Version header).
-
-`get_usage_credits` must be called with an HTTP client authenticated using an admin API key
+`get_usage_credits` must be called with a client authenticated using an admin API key
 (`CARTESIA_ADMIN_API_KEY`); standard API keys are rejected on `/usage/*`.
 """
 
@@ -13,18 +9,13 @@ from __future__ import annotations
 
 import typing
 
-from cartesia.core.http_client import HttpClient
+from cartesia import Cartesia
 
 UsageInterval = typing.Literal["day", "week", "month"]
 
 
-def _json_response(response) -> dict[str, typing.Any]:
-    response.raise_for_status()
-    return response.json()
-
-
 def get_usage_credits(
-    http: HttpClient,
+    client: Cartesia,
     *,
     start_ts: typing.Optional[str] = None,
     end_ts: typing.Optional[str] = None,
@@ -40,66 +31,8 @@ def get_usage_credits(
         params["interval"] = interval
     if api_key_id is not None:
         params["api_key_id"] = api_key_id
-    return _json_response(http.request("usage/credits", method="GET", params=params))
-
-
-def list_pronunciation_dicts(
-    http: HttpClient,
-    *,
-    limit: typing.Optional[int] = None,
-    starting_after: typing.Optional[str] = None,
-    ending_before: typing.Optional[str] = None,
-) -> dict[str, typing.Any]:
-    params: dict[str, typing.Any] = {}
-    if limit is not None:
-        params["limit"] = limit
-    if starting_after is not None:
-        params["starting_after"] = starting_after
-    if ending_before is not None:
-        params["ending_before"] = ending_before
-    return _json_response(
-        http.request("pronunciation-dicts", method="GET", params=params)
+    return client.get(
+        "/usage/credits",
+        cast_to=dict[str, typing.Any],
+        options={"params": params},
     )
-
-
-def create_pronunciation_dict(
-    http: HttpClient,
-    *,
-    name: str,
-    items: typing.Optional[typing.Sequence[dict[str, str]]] = None,
-) -> dict[str, typing.Any]:
-    body: dict[str, typing.Any] = {"name": name}
-    if items is not None:
-        body["items"] = list(items)
-    return _json_response(
-        http.request("pronunciation-dicts", method="POST", json=body)
-    )
-
-
-def get_pronunciation_dict(http: HttpClient, dict_id: str) -> dict[str, typing.Any]:
-    return _json_response(
-        http.request(f"pronunciation-dicts/{dict_id}", method="GET")
-    )
-
-
-def update_pronunciation_dict(
-    http: HttpClient,
-    dict_id: str,
-    *,
-    name: typing.Optional[str] = None,
-    items: typing.Optional[typing.Sequence[dict[str, str]]] = None,
-) -> dict[str, typing.Any]:
-    body: dict[str, typing.Any] = {}
-    if name is not None:
-        body["name"] = name
-    if items is not None:
-        body["items"] = list(items)
-    if not body:
-        raise ValueError("At least one of `name` or `items` must be provided.")
-    return _json_response(
-        http.request(f"pronunciation-dicts/{dict_id}", method="PATCH", json=body)
-    )
-
-
-def delete_pronunciation_dict(http: HttpClient, dict_id: str) -> None:
-    http.request(f"pronunciation-dicts/{dict_id}", method="DELETE").raise_for_status()

--- a/cartesia_mcp/request_options.py
+++ b/cartesia_mcp/request_options.py
@@ -39,7 +39,7 @@ def sdk_kwargs_from_request_options(
         elif "timeout" in request_options:
             kwargs["timeout"] = request_options["timeout"]
 
-        for key in ("extra_headers", "extra_query", "extra_body", "timeout"):
+        for key in ("extra_headers", "extra_query", "extra_body"):
             if key in request_options:
                 if key == "extra_query":
                     query.update(request_options[key])

--- a/cartesia_mcp/request_options.py
+++ b/cartesia_mcp/request_options.py
@@ -70,6 +70,13 @@ def sdk_kwargs_from_request_options(
             if isinstance(extra_json, dict):
                 _merge_extra_body(kwargs, extra_json)
 
+        if "idempotency_key" in request_options:
+            existing = kwargs.get("extra_headers")
+            headers = {"Idempotency-Key": request_options["idempotency_key"]}
+            kwargs["extra_headers"] = (
+                {**existing, **headers} if isinstance(existing, dict) else headers
+            )
+
     if query:
         kwargs["extra_query"] = query
     return kwargs

--- a/cartesia_mcp/request_options.py
+++ b/cartesia_mcp/request_options.py
@@ -1,0 +1,41 @@
+"""
+Map MCP tool request_options onto cartesia-python v3 method kwargs.
+
+MCP tools still accept Fern v2-style RequestOptions dicts for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from cartesia.pagination import SyncCursorIDPage
+
+
+def sdk_kwargs_from_request_options(
+    request_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+    *,
+    extra_query: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+) -> dict[str, typing.Any]:
+    kwargs: dict[str, typing.Any] = {}
+    query = dict(extra_query or {})
+
+    if request_options:
+        if "timeout_in_seconds" in request_options:
+            kwargs["timeout"] = request_options["timeout_in_seconds"]
+        elif "timeout" in request_options:
+            kwargs["timeout"] = request_options["timeout"]
+
+        if "additional_headers" in request_options:
+            kwargs["extra_headers"] = dict(request_options["additional_headers"])
+        elif "headers" in request_options:
+            kwargs["extra_headers"] = dict(request_options["headers"])
+
+        if "additional_query_parameters" in request_options:
+            query.update(request_options["additional_query_parameters"])
+        elif "params" in request_options:
+            query.update(request_options["params"])
+
+    if query:
+        kwargs["extra_query"] = query
+    return kwargs

--- a/cartesia_mcp/request_options.py
+++ b/cartesia_mcp/request_options.py
@@ -12,6 +12,19 @@ if typing.TYPE_CHECKING:
     from cartesia.pagination import SyncCursorIDPage
 
 
+def _merge_extra_body(
+    kwargs: dict[str, typing.Any],
+    extra_fields: dict[str, typing.Any],
+) -> None:
+    if not extra_fields:
+        return
+    existing = kwargs.get("extra_body")
+    if isinstance(existing, dict):
+        kwargs["extra_body"] = {**existing, **extra_fields}
+    else:
+        kwargs["extra_body"] = extra_fields
+
+
 def sdk_kwargs_from_request_options(
     request_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     *,
@@ -26,15 +39,36 @@ def sdk_kwargs_from_request_options(
         elif "timeout" in request_options:
             kwargs["timeout"] = request_options["timeout"]
 
+        for key in ("extra_headers", "extra_query", "extra_body", "timeout"):
+            if key in request_options:
+                if key == "extra_query":
+                    query.update(request_options[key])
+                else:
+                    kwargs[key] = request_options[key]
+
         if "additional_headers" in request_options:
-            kwargs["extra_headers"] = dict(request_options["additional_headers"])
+            existing = kwargs.get("extra_headers")
+            headers = dict(request_options["additional_headers"])
+            kwargs["extra_headers"] = {**existing, **headers} if isinstance(existing, dict) else headers
         elif "headers" in request_options:
-            kwargs["extra_headers"] = dict(request_options["headers"])
+            existing = kwargs.get("extra_headers")
+            headers = dict(request_options["headers"])
+            kwargs["extra_headers"] = {**existing, **headers} if isinstance(existing, dict) else headers
 
         if "additional_query_parameters" in request_options:
             query.update(request_options["additional_query_parameters"])
         elif "params" in request_options:
             query.update(request_options["params"])
+
+        if "additional_body_parameters" in request_options:
+            body = request_options["additional_body_parameters"]
+            if isinstance(body, dict):
+                _merge_extra_body(kwargs, body)
+
+        if "extra_json" in request_options:
+            extra_json = request_options["extra_json"]
+            if isinstance(extra_json, dict):
+                _merge_extra_body(kwargs, extra_json)
 
     if query:
         kwargs["extra_query"] = query

--- a/cartesia_mcp/sdk_setup.py
+++ b/cartesia_mcp/sdk_setup.py
@@ -1,9 +1,8 @@
-"""Configure the Fern Cartesia client for MCP (API version, shared HTTP)."""
+"""Configure the Cartesia Python SDK v3 client for MCP."""
 
 from __future__ import annotations
 
 from cartesia import Cartesia
-from cartesia.core.http_client import HttpClient
 
 from cartesia_mcp.api_version import CARTESIA_VERSION
 from cartesia_mcp.client_headers import client_request_headers
@@ -17,24 +16,10 @@ def is_admin_api_key(api_key: str) -> bool:
 
 
 def create_cartesia_client(api_key: str) -> Cartesia:
-    client = Cartesia(api_key=api_key)
-    _apply_api_version(client._client_wrapper)
-    return client
-
-
-def get_http(client: Cartesia) -> HttpClient:
-    return client._client_wrapper.httpx_client
-
-
-def _apply_api_version(wrapper) -> None:
-    original_get_headers = wrapper.get_headers
-
-    def get_headers() -> dict[str, str]:
-        headers = original_get_headers()
-        headers["Cartesia-Version"] = CARTESIA_VERSION
-        headers.update(client_request_headers())
-        return headers
-
-    wrapper.get_headers = get_headers
-    # HttpClient stores base_headers at init; refresh so extra_api routes pick up the version.
-    wrapper.httpx_client.base_headers = wrapper.get_headers
+    return Cartesia(
+        api_key=api_key,
+        default_headers={
+            "cartesia-version": CARTESIA_VERSION,
+            **client_request_headers(),
+        },
+    )

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -6,6 +6,21 @@ import os
 import typing
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from cartesia import Cartesia, RequestOptions, omit
+from cartesia.types import (
+    GenderPresentation,
+    GenerationConfigParam,
+    OutputFormatContainer,
+    RawEncoding,
+    STTEncoding,
+    STTTranscribeResponse,
+    SupportedLanguage,
+    Voice,
+    VoiceMetadata,
+)
+from cartesia.types.tts_generate_params import OutputFormat
+from cartesia.types.voice_specifier_param import VoiceSpecifierParam
+
 from cartesia_mcp.custom_types import (
     DeletePronunciationDictResult,
     DeleteVoiceResult,
@@ -14,27 +29,16 @@ from cartesia_mcp.custom_types import (
     ListVoicesResult,
     PronunciationDictItemParams,
 )
-from cartesia.voices.requests import LocalizeDialectParams
-from cartesia.voices.types import VoiceMetadata, GenderPresentation, Gender, CloneMode, Voice
-from cartesia.voice_changer.types import OutputFormatContainer
-from cartesia.tts.types import SupportedLanguage, RawEncoding
-from cartesia.tts.requests import OutputFormatParams, TtsRequestVoiceSpecifierParams
-from cartesia.tts.requests.generation_config import GenerationConfigParams
-from cartesia.stt.types.stt_encoding import SttEncoding
-from cartesia.stt.types.timestamp_granularity import TimestampGranularity
-from cartesia.stt.types.transcription_response import TranscriptionResponse
-from cartesia.core.request_options import RequestOptions
-
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
 from cartesia_mcp.extra_api import UsageInterval
-from cartesia_mcp.config import ensure_admin_http, env_or_none, validate_api_keys
-from cartesia_mcp.sdk_setup import create_cartesia_client, get_http
+from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
+from cartesia_mcp.request_options import sdk_kwargs_from_request_options
+from cartesia_mcp.sdk_setup import create_cartesia_client
 from cartesia_mcp.utils import (
-    build_list_voices_request_options,
     create_output_file,
+    cursor_page_to_result,
     iter_stt_audio_chunks,
-    pronunciation_dict_list_to_result,
     voice_list_page_to_result,
 )
 
@@ -48,17 +52,16 @@ CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY = validate_api_keys(
 OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
 client = create_cartesia_client(CARTESIA_API_KEY)
-http = get_http(client)
-admin_http = (
-    get_http(create_cartesia_client(CARTESIA_ADMIN_API_KEY))
+admin_client = (
+    create_cartesia_client(CARTESIA_ADMIN_API_KEY)
     if CARTESIA_ADMIN_API_KEY
     else None
 )
 mcp = FastMCP("Cartesia")
 
 
-def _require_admin_http():
-    return ensure_admin_http(admin_http)
+def _require_admin_client() -> Cartesia:
+    return ensure_admin_client(admin_client)
 
 
 def _build_generation_config(
@@ -66,10 +69,10 @@ def _build_generation_config(
     speed: typing.Optional[float] = None,
     volume: typing.Optional[float] = None,
     emotion: typing.Optional[str] = None,
-) -> typing.Optional[GenerationConfigParams]:
+) -> typing.Optional[GenerationConfigParam]:
     if speed is None and volume is None and emotion is None:
         return None
-    config: GenerationConfigParams = {}
+    config: GenerationConfigParam = {}
     if speed is not None:
         config["speed"] = speed
     if volume is not None:
@@ -114,8 +117,8 @@ def _build_generation_config(
           """)
 def text_to_speech(
     transcript: str,
-    voice: TtsRequestVoiceSpecifierParams,
-    output_format: OutputFormatParams,
+    voice: VoiceSpecifierParam,
+    output_format: OutputFormat,
     model_id: typing.Optional[str] = DEFAULT_MODEL_ID,
     language: typing.Optional[SupportedLanguage] = None,
     duration: typing.Optional[float] = None,
@@ -125,6 +128,7 @@ def text_to_speech(
     pronunciation_dict_id: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> GeneratedAudioResult:
+    _ = duration
     generation_config = _build_generation_config(
         speed=speed,
         volume=volume,
@@ -136,19 +140,17 @@ def text_to_speech(
         "output_format": output_format,
         "model_id": model_id,
         "language": language,
-        "duration": duration,
-        "request_options": request_options,
+        "pronunciation_dict_id": pronunciation_dict_id,
+        **sdk_kwargs_from_request_options(request_options),
     }
     if generation_config is not None:
         tts_kwargs["generation_config"] = generation_config
-    if pronunciation_dict_id is not None:
-        tts_kwargs["pronunciation_dict_id"] = pronunciation_dict_id
-    result = client.tts.bytes(**tts_kwargs)
+    result = client.tts.generate(**tts_kwargs)
 
     output_file = create_output_file(OUTPUT_DIRECTORY, "text_to_speech",
                                         output_format["container"])
 
-    audio_bytes = b"".join(result)
+    audio_bytes = result.read()
     with output_file.open("wb") as f:
         f.write(audio_bytes)
 
@@ -189,16 +191,16 @@ def voice_change(
     request_options: typing.Optional[RequestOptions] = None,
 ) -> GeneratedAudioResult:
     with open(file_path, "rb") as clip:
-        result = client.voice_changer.bytes(
+        result = client.voice_changer.generate(
             clip=clip,
             voice_id=voice_id,
             output_format_container=output_format_container,
             output_format_sample_rate=output_format_sample_rate,
             output_format_encoding=output_format_encoding,
             output_format_bit_rate=output_format_bit_rate,
-            request_options=request_options,
+            **sdk_kwargs_from_request_options(request_options),
         )
-        audio_bytes = b"".join(result)
+        audio_bytes = result.read()
 
     output_file = create_output_file(OUTPUT_DIRECTORY, "voice_change",
                                         output_format_container)
@@ -235,8 +237,8 @@ def localize_voice(
     name: str,
     description: str,
     language: SupportedLanguage,
-    original_speaker_gender: Gender,
-    dialect: typing.Optional[LocalizeDialectParams] = None,
+    original_speaker_gender: typing.Literal["male", "female"],
+    dialect: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
     return client.voices.localize(
@@ -246,7 +248,7 @@ def localize_voice(
         language=language,
         original_speaker_gender=original_speaker_gender,
         dialect=dialect,
-        request_options=request_options,
+        **sdk_kwargs_from_request_options(request_options),
     )
 
 
@@ -263,7 +265,7 @@ def delete_voice(
     voice_id: str,
     request_options: typing.Optional[RequestOptions] = None
 ) -> DeleteVoiceResult:
-    client.voices.delete(id=voice_id, request_options=request_options)
+    client.voices.delete(id=voice_id, **sdk_kwargs_from_request_options(request_options))
     return DeleteVoiceResult(success=True)
 
 @mcp.tool(description="""
@@ -279,7 +281,7 @@ def get_voice(
         voice_id: str,
         request_options: typing.Optional[RequestOptions] = None
 ) -> Voice:
-    return client.voices.get(id=voice_id, request_options=request_options)
+    return client.voices.get(id=voice_id, **sdk_kwargs_from_request_options(request_options))
 
 
 @mcp.tool(description="""
@@ -306,7 +308,7 @@ def update_voice(
         id=voice_id,
         name=name,
         description=description,
-        request_options=request_options,
+        **sdk_kwargs_from_request_options(request_options),
     )
 
 @mcp.tool(description="""
@@ -340,18 +342,18 @@ def clone_voice(
     file_path: str,
     name: str,
     language: SupportedLanguage,
-    mode: CloneMode,
+    mode: str,
     description: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
+    _ = mode
     with open(file_path, "rb") as clip:
         return client.voices.clone(
             clip=clip,
             name=name,
             language=language,
-            mode=mode,
             description=description,
-            request_options=request_options,
+            **sdk_kwargs_from_request_options(request_options),
         )
 
 @mcp.tool(description="""
@@ -407,12 +409,9 @@ def list_voices(
     expand: typing.Optional[typing.Sequence[str]] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> ListVoicesResult:
-    merged_request_options = build_list_voices_request_options(
-        request_options,
-        language=language,
-        q=q,
-        expand=expand,
-    )
+    extra_query: dict[str, typing.Any] = {}
+    if language is not None:
+        extra_query["language"] = language
     pager = client.voices.list(
         limit=limit,
         gender=gender,
@@ -420,7 +419,9 @@ def list_voices(
         is_starred=is_starred,
         starting_after=starting_after,
         ending_before=ending_before,
-        request_options=merged_request_options,
+        q=q,
+        expand=list(expand) if expand else omit,
+        **sdk_kwargs_from_request_options(request_options, extra_query=extra_query),
     )
     return voice_list_page_to_result(pager)
 
@@ -441,16 +442,16 @@ def _speech_to_text_batch(
     file_path: str,
     model: str,
     language: typing.Optional[str],
-    encoding: typing.Optional[SttEncoding],
+    encoding: typing.Optional[STTEncoding],
     sample_rate: typing.Optional[int],
-    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]],
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
     request_options: typing.Optional[RequestOptions],
-) -> TranscriptionResponse:
+) -> STTTranscribeResponse:
     with open(file_path, "rb") as audio_file:
         kwargs: dict[str, typing.Any] = {
             "file": audio_file,
             "model": model,
-            "request_options": request_options,
+            **sdk_kwargs_from_request_options(request_options),
         }
         if language is not None:
             kwargs["language"] = language
@@ -468,10 +469,11 @@ def _speech_to_text_stream(
     file_path: str,
     model: str,
     language: typing.Optional[str],
-    encoding: typing.Optional[SttEncoding],
+    encoding: typing.Optional[STTEncoding],
     sample_rate: typing.Optional[int],
-    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]],
-) -> TranscriptionResponse:
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+) -> STTTranscribeResponse:
+    _ = timestamp_granularities
     stream_encoding, stream_sample_rate, chunks = iter_stt_audio_chunks(
         file_path,
         encoding=encoding,
@@ -479,42 +481,28 @@ def _speech_to_text_stream(
     )
     stt_language = language if language is not None else "en"
     full_text = ""
-    duration: typing.Optional[float] = None
     response_language: typing.Optional[str] = stt_language
-    words: typing.Optional[typing.List[typing.Any]] = None
 
-    for result in client.stt.websocket(
+    with client.stt.auto_finalize.websocket(
         model=model,
-        language=stt_language,
         encoding=stream_encoding,
         sample_rate=stream_sample_rate,
-    ).transcribe(
-        chunks,
-        model=model,
-        language=stt_language,
-        encoding=stream_encoding,
-        sample_rate=stream_sample_rate,
-    ):
-        if result.get("type") != "transcript":
-            continue
-        if result.get("is_final"):
-            full_text += result.get("text", "")
-            if (
-                timestamp_granularities
-                and "word" in timestamp_granularities
-                and "words" in result
-            ):
-                words = result["words"]
-        if "duration" in result:
-            duration = result["duration"]
-        if "language" in result:
-            response_language = result["language"]
+    ) as connection:
+        for chunk in chunks:
+            connection.send_raw(chunk)
 
-    return TranscriptionResponse(
+        connection.send({"type": "close"})
+
+        for event in connection:
+            if event.type == "turn.end":
+                full_text += event.transcript
+            elif event.type == "error":
+                raise RuntimeError(f"STT stream error: {event}")
+
+    return STTTranscribeResponse(
         text=full_text,
+        type="transcript",
         language=response_language,
-        duration=duration,
-        words=words,
     )
 
 
@@ -562,11 +550,11 @@ def speech_to_text(
     mode: SttMode = "batch",
     model: typing.Optional[str] = None,
     language: typing.Optional[str] = None,
-    encoding: typing.Optional[SttEncoding] = None,
+    encoding: typing.Optional[STTEncoding] = None,
     sample_rate: typing.Optional[int] = None,
-    timestamp_granularities: typing.Optional[typing.Sequence[TimestampGranularity]] = None,
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]] = None,
     request_options: typing.Optional[RequestOptions] = None,
-) -> TranscriptionResponse:
+) -> STTTranscribeResponse:
     stt_model = _resolve_stt_model(mode, model)
     if mode == "stream":
         _ = request_options
@@ -614,7 +602,7 @@ def get_credit_usage(
     api_key_id: typing.Optional[str] = None,
 ) -> dict[str, typing.Any]:
     return extra_api.get_usage_credits(
-        _require_admin_http(),
+        _require_admin_client(),
         start_ts=start_ts,
         end_ts=end_ts,
         interval=interval,
@@ -641,13 +629,12 @@ def list_pronunciation_dicts(
     starting_after: typing.Optional[str] = None,
     ending_before: typing.Optional[str] = None,
 ) -> ListPronunciationDictsResult:
-    payload = extra_api.list_pronunciation_dicts(
-        http,
+    page = client.pronunciation_dicts.list(
         limit=limit,
         starting_after=starting_after,
         ending_before=ending_before,
     )
-    return pronunciation_dict_list_to_result(payload)
+    return typing.cast(ListPronunciationDictsResult, cursor_page_to_result(page))
 
 
 @mcp.tool(description="""
@@ -664,7 +651,10 @@ def create_pronunciation_dict(
     name: str,
     items: typing.Optional[typing.Sequence[PronunciationDictItemParams]] = None,
 ) -> dict[str, typing.Any]:
-    return extra_api.create_pronunciation_dict(http, name=name, items=items)
+    return client.pronunciation_dicts.create(
+        name=name,
+        items=list(items) if items is not None else omit,
+    ).model_dump(mode="json")
 
 
 @mcp.tool(description="""
@@ -674,7 +664,7 @@ def create_pronunciation_dict(
             Pronunciation dictionary ID.
         """)
 def get_pronunciation_dict(dict_id: str) -> dict[str, typing.Any]:
-    return extra_api.get_pronunciation_dict(http, dict_id)
+    return client.pronunciation_dicts.retrieve(dict_id).model_dump(mode="json")
 
 
 @mcp.tool(description="""
@@ -693,7 +683,14 @@ def update_pronunciation_dict(
     name: typing.Optional[str] = None,
     items: typing.Optional[typing.Sequence[PronunciationDictItemParams]] = None,
 ) -> dict[str, typing.Any]:
-    return extra_api.update_pronunciation_dict(http, dict_id, name=name, items=items)
+    if name is None and items is None:
+        raise ValueError("At least one of `name` or `items` must be provided.")
+    kwargs: dict[str, typing.Any] = {}
+    if name is not None:
+        kwargs["name"] = name
+    if items is not None:
+        kwargs["items"] = list(items)
+    return client.pronunciation_dicts.update(dict_id, **kwargs).model_dump(mode="json")
 
 
 @mcp.tool(description="""
@@ -703,7 +700,7 @@ def update_pronunciation_dict(
             Pronunciation dictionary ID to delete.
         """)
 def delete_pronunciation_dict(dict_id: str) -> DeletePronunciationDictResult:
-    extra_api.delete_pronunciation_dict(http, dict_id)
+    client.pronunciation_dicts.delete(dict_id)
     return DeletePronunciationDictResult(success=True)
 
 

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -18,6 +18,8 @@ from cartesia.types import (
     Voice,
     VoiceMetadata,
 )
+from cartesia.types.shared.word_timestamps import WordTimestamps
+from cartesia.types.stt_transcribe_response import Word as SttWord
 from cartesia.types.tts_generate_params import OutputFormat
 from cartesia.types.voice_specifier_param import VoiceSpecifierParam
 
@@ -81,6 +83,38 @@ def _build_generation_config(
         config["emotion"] = emotion
     return config
 
+
+def _merge_extra_body(
+    sdk_kwargs: dict[str, typing.Any],
+    extra_fields: dict[str, typing.Any],
+) -> None:
+    if not extra_fields:
+        return
+    existing = sdk_kwargs.get("extra_body")
+    if isinstance(existing, dict):
+        sdk_kwargs["extra_body"] = {**existing, **extra_fields}
+    else:
+        sdk_kwargs["extra_body"] = extra_fields
+
+
+def _stt_words_from_timestamps(
+    word_timestamp_groups: typing.Optional[typing.Sequence[WordTimestamps]],
+) -> typing.Optional[typing.List[SttWord]]:
+    if not word_timestamp_groups:
+        return None
+    words: list[SttWord] = []
+    for group in word_timestamp_groups:
+        for word, start, end in zip(group.words, group.start, group.end):
+            words.append(SttWord(word=word, start=start, end=end))
+    return words or None
+
+
+def _wants_word_timestamps(
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+) -> bool:
+    return bool(timestamp_granularities and "word" in timestamp_granularities)
+
+
 @mcp.tool(description="""
         Parameters
         ----------
@@ -128,7 +162,6 @@ def text_to_speech(
     pronunciation_dict_id: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> GeneratedAudioResult:
-    _ = duration
     generation_config = _build_generation_config(
         speed=speed,
         volume=volume,
@@ -145,6 +178,8 @@ def text_to_speech(
     }
     if generation_config is not None:
         tts_kwargs["generation_config"] = generation_config
+    if duration is not None:
+        _merge_extra_body(tts_kwargs, {"duration": duration})
     result = client.tts.generate(**tts_kwargs)
 
     output_file = create_output_file(OUTPUT_DIRECTORY, "text_to_speech",
@@ -346,14 +381,15 @@ def clone_voice(
     description: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
-    _ = mode
+    clone_kwargs = sdk_kwargs_from_request_options(request_options)
+    _merge_extra_body(clone_kwargs, {"mode": mode})
     with open(file_path, "rb") as clip:
         return client.voices.clone(
             clip=clip,
             name=name,
             language=language,
             description=description,
-            **sdk_kwargs_from_request_options(request_options),
+            **clone_kwargs,
         )
 
 @mcp.tool(description="""
@@ -464,24 +500,15 @@ def _speech_to_text_batch(
         return client.stt.transcribe(**kwargs)
 
 
-def _speech_to_text_stream(
+def _speech_to_text_stream_auto_finalize(
     *,
-    file_path: str,
     model: str,
-    language: typing.Optional[str],
-    encoding: typing.Optional[STTEncoding],
-    sample_rate: typing.Optional[int],
-    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+    stream_encoding: STTEncoding,
+    stream_sample_rate: int,
+    chunks: typing.Iterable[bytes],
+    response_language: typing.Optional[str],
 ) -> STTTranscribeResponse:
-    _ = timestamp_granularities
-    stream_encoding, stream_sample_rate, chunks = iter_stt_audio_chunks(
-        file_path,
-        encoding=encoding,
-        sample_rate=sample_rate,
-    )
-    stt_language = language if language is not None else "en"
     full_text = ""
-    response_language: typing.Optional[str] = stt_language
 
     with client.stt.auto_finalize.websocket(
         model=model,
@@ -503,6 +530,101 @@ def _speech_to_text_stream(
         text=full_text,
         type="transcript",
         language=response_language,
+    )
+
+
+def _speech_to_text_stream_manual_finalize(
+    *,
+    model: str,
+    stream_encoding: STTEncoding,
+    stream_sample_rate: int,
+    chunks: typing.Iterable[bytes],
+    language: typing.Optional[str],
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+) -> STTTranscribeResponse:
+    stt_language = language if language is not None else "en"
+    extra_query: dict[str, typing.Any] = {}
+    if language is not None and language != "en":
+        extra_query["language"] = language
+    if _wants_word_timestamps(timestamp_granularities):
+        extra_query["timestamp_granularities[]"] = "word"
+
+    websocket_kwargs: dict[str, typing.Any] = {
+        "model": model,
+        "encoding": stream_encoding,
+        "sample_rate": stream_sample_rate,
+    }
+    if stt_language == "en":
+        websocket_kwargs["language"] = "en"
+    if extra_query:
+        websocket_kwargs["extra_query"] = extra_query
+
+    full_text = ""
+    duration: typing.Optional[float] = None
+    response_language: typing.Optional[str] = stt_language
+    words: typing.Optional[typing.List[SttWord]] = None
+
+    with client.stt.manual_finalize.websocket(**websocket_kwargs) as connection:
+        for chunk in chunks:
+            connection.send_raw(chunk)
+
+        connection.send("finalize")
+        connection.send("close")
+
+        for event in connection:
+            if event.type == "transcript":
+                if event.is_final:
+                    full_text += event.text
+                    if _wants_word_timestamps(timestamp_granularities) and event.words:
+                        words = _stt_words_from_timestamps(event.words)
+                if event.duration is not None:
+                    duration = event.duration
+                if event.language is not None:
+                    response_language = event.language
+            elif event.type == "error":
+                raise RuntimeError(f"STT stream error: {event}")
+
+    return STTTranscribeResponse(
+        text=full_text,
+        type="transcript",
+        language=response_language,
+        duration=duration,
+        words=words,
+    )
+
+
+def _speech_to_text_stream(
+    *,
+    file_path: str,
+    model: str,
+    language: typing.Optional[str],
+    encoding: typing.Optional[STTEncoding],
+    sample_rate: typing.Optional[int],
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+) -> STTTranscribeResponse:
+    stream_encoding, stream_sample_rate, chunks = iter_stt_audio_chunks(
+        file_path,
+        encoding=encoding,
+        sample_rate=sample_rate,
+    )
+    stt_language = language if language is not None else "en"
+
+    if _wants_word_timestamps(timestamp_granularities):
+        return _speech_to_text_stream_manual_finalize(
+            model=model,
+            stream_encoding=stream_encoding,
+            stream_sample_rate=stream_sample_rate,
+            chunks=chunks,
+            language=language,
+            timestamp_granularities=timestamp_granularities,
+        )
+
+    return _speech_to_text_stream_auto_finalize(
+        model=model,
+        stream_encoding=stream_encoding,
+        stream_sample_rate=stream_sample_rate,
+        chunks=chunks,
+        response_language=stt_language,
     )
 
 

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -115,6 +115,16 @@ def _wants_word_timestamps(
     return bool(timestamp_granularities and "word" in timestamp_granularities)
 
 
+def _stream_stt_uses_manual_finalize(
+    *,
+    language: typing.Optional[str],
+    timestamp_granularities: typing.Optional[typing.Sequence[typing.Literal["word"]]],
+) -> bool:
+    if _wants_word_timestamps(timestamp_granularities):
+        return True
+    return language is not None and language != "en"
+
+
 @mcp.tool(description="""
         Parameters
         ----------
@@ -609,7 +619,10 @@ def _speech_to_text_stream(
     )
     stt_language = language if language is not None else "en"
 
-    if _wants_word_timestamps(timestamp_granularities):
+    if _stream_stt_uses_manual_finalize(
+        language=language,
+        timestamp_granularities=timestamp_granularities,
+    ):
         return _speech_to_text_stream_manual_finalize(
             model=model,
             stream_encoding=stream_encoding,

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -156,7 +156,7 @@ def _stream_stt_uses_manual_finalize(
             Pronunciation dictionary ID to apply for this generation only.
 
         request_options : typing.Optional[RequestOptions]
-            Request-specific configuration. You can pass in configuration such as `chunk_size`, and more to customize the request and response.
+            Request-specific configuration (timeout, headers, query params, extra body fields).
 
           """)
 def text_to_speech(
@@ -223,8 +223,8 @@ def text_to_speech(
             Required for `mp3` containers.
 
         request_options : typing.Optional[RequestOptions]
-            Request-specific configuration. You can pass in configuration such as `chunk_size`, and more to customize the request and response.
-          
+            Request-specific configuration (timeout, headers, query params).
+
         """)
 def voice_change(
     file_path: str,
@@ -458,11 +458,12 @@ def list_voices(
     extra_query: dict[str, typing.Any] = {}
     if language is not None:
         extra_query["language"] = language
+    if is_starred is not None:
+        extra_query["is_starred"] = is_starred
     pager = client.voices.list(
         limit=limit,
         gender=gender,
         is_owner=is_owner,
-        is_starred=is_starred,
         starting_after=starting_after,
         ending_before=ending_before,
         q=q,

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -4,18 +4,16 @@ import typing
 import wave
 from pathlib import Path
 
-from cartesia.stt.types.stt_encoding import SttEncoding
+from cartesia.pagination import SyncCursorIDPage
+from cartesia.types import OutputFormatContainer, STTEncoding, Voice
 from cartesia_mcp.custom_types import (
     ListPronunciationDictsResult,
     ListVoicesResult,
     ToolType,
 )
-from cartesia.core.pagination import SyncPager
-from cartesia.core.request_options import RequestOptions
-from cartesia.voice_changer.types import OutputFormatContainer
-from cartesia.voices.types import Voice
 
-_BYTES_PER_SAMPLE: dict[SttEncoding, int] = {
+
+_BYTES_PER_SAMPLE: dict[STTEncoding, int] = {
     "pcm_s16le": 2,
     "pcm_s32le": 4,
     "pcm_f16le": 2,
@@ -25,7 +23,7 @@ _BYTES_PER_SAMPLE: dict[SttEncoding, int] = {
 }
 
 
-def _wav_encoding(sample_width: int) -> SttEncoding:
+def _wav_encoding(sample_width: int) -> STTEncoding:
     if sample_width == 2:
         return "pcm_s16le"
     if sample_width == 4:
@@ -35,7 +33,7 @@ def _wav_encoding(sample_width: int) -> SttEncoding:
     )
 
 
-def _read_pcm_chunks(file_path: str, *, encoding: SttEncoding, sample_rate: int) -> typing.Iterator[bytes]:
+def _read_pcm_chunks(file_path: str, *, encoding: STTEncoding, sample_rate: int) -> typing.Iterator[bytes]:
     bytes_per_sample = _BYTES_PER_SAMPLE[encoding]
     chunk_bytes = max(sample_rate * bytes_per_sample // 10, 1)
 
@@ -47,7 +45,7 @@ def _read_pcm_chunks(file_path: str, *, encoding: SttEncoding, sample_rate: int)
     return _iter()
 
 
-def _read_wav_chunks(file_path: str) -> tuple[SttEncoding, int, typing.Iterator[bytes]]:
+def _read_wav_chunks(file_path: str) -> tuple[STTEncoding, int, typing.Iterator[bytes]]:
     with wave.open(file_path, "rb") as wf:
         if wf.getnchannels() != 1:
             raise ValueError(f"WAV must be mono, got {wf.getnchannels()} channels.")
@@ -71,9 +69,9 @@ def _read_wav_chunks(file_path: str) -> tuple[SttEncoding, int, typing.Iterator[
 def iter_stt_audio_chunks(
     file_path: str,
     *,
-    encoding: typing.Optional[SttEncoding] = None,
+    encoding: typing.Optional[STTEncoding] = None,
     sample_rate: typing.Optional[int] = None,
-) -> tuple[SttEncoding, int, typing.Iterator[bytes]]:
+) -> tuple[STTEncoding, int, typing.Iterator[bytes]]:
     """Prepare PCM chunks for STT WebSocket streaming."""
     path = Path(file_path)
     if path.suffix.lower() == ".wav":
@@ -104,36 +102,19 @@ def create_output_file(output_directory: str, tool_type: ToolType,
     return dir_path / f"{tool_type}_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.{extension}"
 
 
-def build_list_voices_request_options(
-    request_options: typing.Optional[RequestOptions],
-    *,
-    language: typing.Optional[str] = None,
-    q: typing.Optional[str] = None,
-    expand: typing.Optional[typing.Sequence[str]] = None,
-) -> typing.Optional[RequestOptions]:
-    extra_query: dict[str, typing.Any] = {}
-    if language is not None:
-        extra_query["language"] = language
-    if q is not None:
-        extra_query["q"] = q
-    if expand:
-        extra_query["expand[]"] = list(expand)
-    if not extra_query:
-        return request_options
-
-    merged: RequestOptions = dict(request_options or {})
-    base = dict(merged.get("additional_query_parameters") or {})
-    base.update(extra_query)
-    merged["additional_query_parameters"] = base
-    return merged
-
-
-def voice_list_page_to_result(pager: SyncPager[Voice]) -> ListVoicesResult:
-    data = [voice.model_dump(mode="json") for voice in pager.items]
-    result: ListVoicesResult = {"data": data, "has_more": pager.has_next}
-    if pager.has_next and data:
+def cursor_page_to_result(page: SyncCursorIDPage[typing.Any]) -> dict[str, typing.Any]:
+    data = [item.model_dump(mode="json") for item in page.data]
+    result: dict[str, typing.Any] = {
+        "data": data,
+        "has_more": page.has_next_page(),
+    }
+    if page.has_next_page() and data:
         result["next_page"] = data[-1]["id"]
     return result
+
+
+def voice_list_page_to_result(page: SyncCursorIDPage[Voice]) -> ListVoicesResult:
+    return typing.cast(ListVoicesResult, cursor_page_to_result(page))
 
 
 def pronunciation_dict_list_to_result(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    # SDK v3 moved modules (e.g. cartesia.core); server still targets v2 APIs — pin until migrated.
-    "cartesia>=2.0.17,<3.0.0",
+    "cartesia[websockets]>=3.2.0,<4.0.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.7.1",
 ]

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -180,7 +180,7 @@ def main() -> int:
                 failures.append("speech_to_text(stream)(empty)")
                 print("  FAIL speech_to_text(stream): empty transcript")
 
-    if s.admin_http is not None:
+    if s.admin_client is not None:
         run("get_credit_usage", lambda: s.get_credit_usage())
     else:
         print("  SKIP get_credit_usage — set CARTESIA_ADMIN_API_KEY to test")

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, mock_open, patch
+
+import cartesia_mcp.server as server
+from cartesia.types.shared.word_timestamps import WordTimestamps
+from cartesia.types.stt_transcribe_response import Word as SttWord
+
+
+def test_stt_words_from_timestamps_flattens_word_timestamps() -> None:
+    words = server._stt_words_from_timestamps(
+        [WordTimestamps(words=["hello", "world"], start=[0.0, 0.5], end=[0.4, 1.0])]
+    )
+    assert words == [
+        SttWord(word="hello", start=0.0, end=0.4),
+        SttWord(word="world", start=0.5, end=1.0),
+    ]
+
+
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -> None:
+    mock_client.tts.generate.return_value = MagicMock(read=lambda: b"audio")
+
+    with patch("cartesia_mcp.server.create_output_file") as mock_output:
+        mock_output.return_value.open.return_value.__enter__ = MagicMock()
+        mock_output.return_value.open.return_value.__exit__ = MagicMock(return_value=False)
+        server.text_to_speech(
+            transcript="hello",
+            voice={"mode": "id", "id": "voice-id"},
+            output_format={"container": "wav", "sample_rate": 44100},
+            duration=12.5,
+        )
+
+    kwargs = mock_client.tts.generate.call_args.kwargs
+    assert kwargs["extra_body"] == {"duration": 12.5}
+
+
+@patch("cartesia_mcp.server.client")
+def test_clone_voice_passes_mode_via_extra_body(mock_client: MagicMock) -> None:
+    mock_client.voices.clone.return_value = MagicMock()
+
+    with patch("builtins.open", mock_open(read_data=b"clip")):
+        server.clone_voice(
+            file_path="/tmp/clip.wav",
+            name="Test Voice",
+            language="en",
+            mode="stability",
+            description="desc",
+        )
+
+    kwargs = mock_client.voices.clone.call_args.kwargs
+    assert kwargs["extra_body"] == {"mode": "stability"}
+
+
+@patch("cartesia_mcp.server.client")
+@patch("cartesia_mcp.server.iter_stt_audio_chunks")
+def test_speech_to_text_stream_word_timestamps_use_manual_finalize(
+    mock_iter_chunks: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    mock_iter_chunks.return_value = ("pcm_s16le", 44100, iter([b"chunk"]))
+    mock_connection = MagicMock()
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = False
+    mock_connection.__iter__.return_value = iter(
+        [
+            MagicMock(
+                type="transcript",
+                is_final=True,
+                text="hello",
+                duration=1.2,
+                language="en",
+                words=[
+                    WordTimestamps(words=["hello"], start=[0.0], end=[0.5]),
+                ],
+            )
+        ]
+    )
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.__enter__.return_value = mock_connection
+    mock_ws_manager.__exit__.return_value = False
+    mock_client.stt.manual_finalize.websocket.return_value = mock_ws_manager
+
+    result = server.speech_to_text(
+        "/tmp/sample.wav",
+        mode="stream",
+        timestamp_granularities=["word"],
+    )
+
+    assert result.text == "hello"
+    assert result.duration == 1.2
+    assert result.words == [SttWord(word="hello", start=0.0, end=0.5)]
+    mock_client.stt.manual_finalize.websocket.assert_called_once()
+    websocket_kwargs = mock_client.stt.manual_finalize.websocket.call_args.kwargs
+    assert websocket_kwargs["extra_query"] == {"timestamp_granularities[]": "word"}
+    mock_connection.send.assert_any_call("finalize")
+    mock_connection.send.assert_any_call("close")
+    mock_client.stt.auto_finalize.websocket.assert_not_called()

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -54,6 +54,33 @@ def test_clone_voice_passes_mode_via_extra_body(mock_client: MagicMock) -> None:
 
 @patch("cartesia_mcp.server.client")
 @patch("cartesia_mcp.server.iter_stt_audio_chunks")
+def test_speech_to_text_stream_non_english_uses_manual_finalize(
+    mock_iter_chunks: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    mock_iter_chunks.return_value = ("pcm_s16le", 44100, iter([b"chunk"]))
+    mock_connection = MagicMock()
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = False
+    mock_connection.__iter__.return_value = iter(
+        [MagicMock(type="transcript", is_final=True, text="hola", language="es")]
+    )
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.__enter__.return_value = mock_connection
+    mock_ws_manager.__exit__.return_value = False
+    mock_client.stt.manual_finalize.websocket.return_value = mock_ws_manager
+
+    result = server.speech_to_text("/tmp/sample.wav", mode="stream", language="es")
+
+    assert result.text == "hola"
+    mock_client.stt.manual_finalize.websocket.assert_called_once()
+    websocket_kwargs = mock_client.stt.manual_finalize.websocket.call_args.kwargs
+    assert websocket_kwargs["extra_query"] == {"language": "es"}
+    mock_client.stt.auto_finalize.websocket.assert_not_called()
+
+
+@patch("cartesia_mcp.server.client")
+@patch("cartesia_mcp.server.iter_stt_audio_chunks")
 def test_speech_to_text_stream_word_timestamps_use_manual_finalize(
     mock_iter_chunks: MagicMock,
     mock_client: MagicMock,

--- a/tests/test_client_attribution.py
+++ b/tests/test_client_attribution.py
@@ -1,0 +1,50 @@
+"""Assert cartesia-mcp identifies itself on REST and STT WebSocket paths."""
+
+from __future__ import annotations
+
+import pytest
+
+from cartesia_mcp.client_headers import client_header
+from cartesia_mcp.sdk_setup import create_cartesia_client
+
+
+def test_create_cartesia_client_default_headers_match_attribution() -> None:
+    client = create_cartesia_client("sk_car_test_key")
+    header = client_header()
+
+    assert client.default_headers["User-Agent"] == header
+    assert client.default_headers["X-Cartesia-Client"] == header
+
+
+def test_stt_auto_finalize_connect_merges_default_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = create_cartesia_client("sk_car_test_key")
+    captured: dict[str, object] = {}
+
+    class FakeConnection:
+        def recv(self, decode=False):  # noqa: ARG002
+            raise StopIteration
+
+        def send(self, _data):  # noqa: ANN001
+            return None
+
+        def close(self, *, code=1000, reason=""):  # noqa: ARG002
+            return None
+
+    def fake_connect(*_args, **kwargs):
+        captured.update(kwargs)
+        return FakeConnection()
+
+    monkeypatch.setattr("websockets.sync.client.connect", fake_connect)
+
+    with pytest.raises(StopIteration):
+        with client.stt.auto_finalize.websocket(
+            encoding="pcm_s16le",
+            model="ink-2",
+            sample_rate=16000,
+        ) as connection:
+            connection.recv()
+
+    header = client_header()
+    assert captured["user_agent_header"] == client.user_agent
+    assert captured["additional_headers"]["User-Agent"] == header
+    assert captured["additional_headers"]["X-Cartesia-Client"] == header

--- a/tests/test_client_headers.py
+++ b/tests/test_client_headers.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from cartesia_mcp.client_headers import USER_AGENT_PREFIX, client_request_headers, user_agent
+from cartesia_mcp.client_headers import CLIENT_ID, client_header, client_request_headers
 
 
-def test_user_agent_format() -> None:
-    ua = user_agent()
-    assert ua.startswith(f"{USER_AGENT_PREFIX} ")
-    assert len(ua.split()) >= 2
+def test_client_header_format() -> None:
+    header = client_header()
+    assert header.startswith(f"{CLIENT_ID}/")
 
 
 def test_client_request_headers() -> None:
+    header = client_header()
     headers = client_request_headers()
-    assert headers == {"User-Agent": user_agent()}
+    assert headers == {
+        "User-Agent": header,
+        "X-Cartesia-Client": header,
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import pytest
 
 from cartesia_mcp.config import (
     ADMIN_HTTP_REQUIRED_MESSAGE,
-    ensure_admin_http,
+    ensure_admin_client,
     env_or_none,
     validate_api_keys,
 )
@@ -62,14 +62,14 @@ class TestValidateApiKeys:
         assert admin == ADMIN_KEY
 
 
-class TestEnsureAdminHttp:
+class TestEnsureAdminClient:
     def test_raises_when_unset(self) -> None:
         with pytest.raises(ValueError, match="CARTESIA_ADMIN_API_KEY"):
-            ensure_admin_http(None)
+            ensure_admin_client(None)
 
     def test_returns_client(self) -> None:
         sentinel = object()
-        assert ensure_admin_http(sentinel) is sentinel
+        assert ensure_admin_client(sentinel) is sentinel
 
     def test_message_documents_playground(self) -> None:
         assert "Keys → Admin" in ADMIN_HTTP_REQUIRED_MESSAGE

--- a/tests/test_list_voices.py
+++ b/tests/test_list_voices.py
@@ -1,0 +1,14 @@
+from unittest.mock import MagicMock, patch
+
+import cartesia_mcp.server as server
+
+
+@patch("cartesia_mcp.server.client")
+def test_list_voices_passes_is_starred_via_extra_query(mock_client: MagicMock) -> None:
+    mock_client.voices.list.return_value = MagicMock(data=[])
+
+    server.list_voices(is_starred=True, language="it")
+
+    kwargs = mock_client.voices.list.call_args.kwargs
+    assert "is_starred" not in kwargs
+    assert kwargs["extra_query"] == {"language": "it", "is_starred": True}

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -27,3 +27,21 @@ def test_sdk_kwargs_forwards_native_v3_keys() -> None:
     assert kwargs["timeout"] == 30
     assert kwargs["extra_headers"] == {"X-Test": "1"}
     assert kwargs["extra_query"] == {"foo": "bar"}
+
+
+def test_sdk_kwargs_forwards_idempotency_key_to_header() -> None:
+    kwargs = sdk_kwargs_from_request_options({"idempotency_key": "req-123"})
+    assert kwargs["extra_headers"] == {"Idempotency-Key": "req-123"}
+
+
+def test_sdk_kwargs_merges_fern_timeout_and_headers() -> None:
+    kwargs = sdk_kwargs_from_request_options(
+        {
+            "timeout_in_seconds": 45,
+            "additional_headers": {"X-Trace": "abc"},
+            "additional_query_parameters": {"expand": "preview_file_url"},
+        }
+    )
+    assert kwargs["timeout"] == 45
+    assert kwargs["extra_headers"] == {"X-Trace": "abc"}
+    assert kwargs["extra_query"] == {"expand": "preview_file_url"}

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -45,3 +45,8 @@ def test_sdk_kwargs_merges_fern_timeout_and_headers() -> None:
     assert kwargs["timeout"] == 45
     assert kwargs["extra_headers"] == {"X-Trace": "abc"}
     assert kwargs["extra_query"] == {"expand": "preview_file_url"}
+
+
+def test_sdk_kwargs_prefers_timeout_in_seconds_over_timeout() -> None:
+    kwargs = sdk_kwargs_from_request_options({"timeout_in_seconds": 45, "timeout": 30})
+    assert kwargs["timeout"] == 45

--- a/tests/test_request_options.py
+++ b/tests/test_request_options.py
@@ -1,0 +1,29 @@
+from cartesia_mcp.request_options import sdk_kwargs_from_request_options
+
+
+def test_sdk_kwargs_forwards_extra_json_as_extra_body() -> None:
+    kwargs = sdk_kwargs_from_request_options({"extra_json": {"duration": 12.0}})
+    assert kwargs["extra_body"] == {"duration": 12.0}
+
+
+def test_sdk_kwargs_merges_additional_body_parameters() -> None:
+    kwargs = sdk_kwargs_from_request_options(
+        {
+            "additional_body_parameters": {"duration": 10.0},
+            "extra_json": {"save": True},
+        }
+    )
+    assert kwargs["extra_body"] == {"duration": 10.0, "save": True}
+
+
+def test_sdk_kwargs_forwards_native_v3_keys() -> None:
+    kwargs = sdk_kwargs_from_request_options(
+        {
+            "timeout": 30,
+            "extra_headers": {"X-Test": "1"},
+            "extra_query": {"foo": "bar"},
+        }
+    )
+    assert kwargs["timeout"] == 30
+    assert kwargs["extra_headers"] == {"X-Test": "1"}
+    assert kwargs["extra_query"] == {"foo": "bar"}

--- a/tests/test_sdk_setup.py
+++ b/tests/test_sdk_setup.py
@@ -1,26 +1,16 @@
-"""Tests for Cartesia client header wiring in sdk_setup."""
+"""Tests for Cartesia SDK v3 client setup."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from cartesia_mcp.api_version import CARTESIA_VERSION
-from cartesia_mcp.client_headers import user_agent
-from cartesia_mcp.sdk_setup import _apply_api_version
+from cartesia_mcp.client_headers import client_request_headers
+from cartesia_mcp.sdk_setup import create_cartesia_client
 
 
-def test_apply_api_version_sets_mcp_user_agent() -> None:
-    wrapper = MagicMock()
-    wrapper.get_headers.return_value = {
-        "X-Fern-Language": "Python",
-        "X-Fern-SDK-Name": "cartesia",
-        "X-Fern-SDK-Version": "2.0.17",
-    }
-    wrapper.httpx_client = MagicMock()
+def test_create_cartesia_client_sets_default_headers() -> None:
+    client = create_cartesia_client("sk_car_test_key")
 
-    _apply_api_version(wrapper)
-
-    headers = wrapper.get_headers()
-    assert headers["Cartesia-Version"] == CARTESIA_VERSION
-    assert headers["User-Agent"] == user_agent()
-    assert wrapper.httpx_client.base_headers == wrapper.get_headers
+    headers = client.default_headers
+    assert headers["cartesia-version"] == CARTESIA_VERSION
+    assert headers["User-Agent"] == client_request_headers()["User-Agent"]
+    assert headers["X-Cartesia-Client"] == client_request_headers()["X-Cartesia-Client"]

--- a/tests/test_speech_to_text_modes.py
+++ b/tests/test_speech_to_text_modes.py
@@ -16,12 +16,12 @@ def test_resolve_stt_model_override() -> None:
 
 @patch("cartesia_mcp.server.client")
 def test_speech_to_text_batch_uses_transcribe(mock_client: MagicMock) -> None:
-    mock_client.stt.transcribe.return_value = {"text": "hello"}
+    mock_client.stt.transcribe.return_value = MagicMock(text="hello")
 
     with patch("builtins.open", mock_open(read_data=b"audio")):
         result = server.speech_to_text("/tmp/sample.mp3", mode="batch", language="en")
 
-    assert result == {"text": "hello"}
+    assert result.text == "hello"
     mock_client.stt.transcribe.assert_called_once()
     kwargs = mock_client.stt.transcribe.call_args.kwargs
     assert kwargs["model"] == "ink-whisper"
@@ -30,19 +30,25 @@ def test_speech_to_text_batch_uses_transcribe(mock_client: MagicMock) -> None:
 
 @patch("cartesia_mcp.server.client")
 @patch("cartesia_mcp.server.iter_stt_audio_chunks")
-def test_speech_to_text_stream_uses_websocket(
+def test_speech_to_text_stream_uses_auto_finalize_websocket(
     mock_iter_chunks: MagicMock,
     mock_client: MagicMock,
 ) -> None:
     mock_iter_chunks.return_value = ("pcm_s16le", 44100, iter([b"chunk"]))
-    mock_ws = MagicMock()
-    mock_client.stt.websocket.return_value = mock_ws
-    mock_ws.transcribe.return_value = [
-        {"type": "transcript", "is_final": True, "text": "hello world"},
-    ]
+    mock_connection = MagicMock()
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = False
+    mock_connection.__iter__.return_value = iter(
+        [MagicMock(type="turn.end", transcript="hello world")]
+    )
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.__enter__.return_value = mock_connection
+    mock_ws_manager.__exit__.return_value = False
+    mock_client.stt.auto_finalize.websocket.return_value = mock_ws_manager
 
     result = server.speech_to_text("/tmp/sample.wav", mode="stream")
 
     assert result.text == "hello world"
-    mock_client.stt.websocket.assert_called_once()
-    mock_ws.transcribe.assert_called_once()
+    mock_client.stt.auto_finalize.websocket.assert_called_once()
+    mock_connection.send_raw.assert_called_once_with(b"chunk")
+    mock_connection.send.assert_called_once_with({"type": "close"})

--- a/uv.lock
+++ b/uv.lock
@@ -3,60 +3,6 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
-name = "aiohappyeyeballs"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
-]
-
-[[package]]
-name = "aiohttp"
-version = "3.11.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/e7/fa1a8c00e2c54b05dc8cb5d1439f627f7c267874e3f7bb047146116020f9/aiohttp-3.11.18.tar.gz", hash = "sha256:ae856e1138612b7e412db63b7708735cff4d38d0399f6a5435d3dac2669f558a", size = 7678653, upload-time = "2025-04-21T09:43:09.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/18/be8b5dd6b9cf1b2172301dbed28e8e5e878ee687c21947a6c81d6ceaa15d/aiohttp-3.11.18-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:474215ec618974054cf5dc465497ae9708543cbfc312c65212325d4212525811", size = 699833, upload-time = "2025-04-21T09:42:00.298Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/84/ecdc68e293110e6f6f6d7b57786a77555a85f70edd2b180fb1fafaff361a/aiohttp-3.11.18-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ced70adf03920d4e67c373fd692123e34d3ac81dfa1c27e45904a628567d804", size = 462774, upload-time = "2025-04-21T09:42:02.015Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/85/f07718cca55884dad83cc2433746384d267ee970e91f0dcc75c6d5544079/aiohttp-3.11.18-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d9f6c0152f8d71361905aaf9ed979259537981f47ad099c8b3d81e0319814bd", size = 454429, upload-time = "2025-04-21T09:42:03.728Z" },
-    { url = "https://files.pythonhosted.org/packages/82/02/7f669c3d4d39810db8842c4e572ce4fe3b3a9b82945fdd64affea4c6947e/aiohttp-3.11.18-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a35197013ed929c0aed5c9096de1fc5a9d336914d73ab3f9df14741668c0616c", size = 1670283, upload-time = "2025-04-21T09:42:06.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/79/b82a12f67009b377b6c07a26bdd1b81dab7409fc2902d669dbfa79e5ac02/aiohttp-3.11.18-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:540b8a1f3a424f1af63e0af2d2853a759242a1769f9f1ab053996a392bd70118", size = 1717231, upload-time = "2025-04-21T09:42:07.953Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/38/d5a1f28c3904a840642b9a12c286ff41fc66dfa28b87e204b1f242dbd5e6/aiohttp-3.11.18-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9e6710ebebfce2ba21cee6d91e7452d1125100f41b906fb5af3da8c78b764c1", size = 1769621, upload-time = "2025-04-21T09:42:09.855Z" },
-    { url = "https://files.pythonhosted.org/packages/53/2d/deb3749ba293e716b5714dda06e257f123c5b8679072346b1eb28b766a0b/aiohttp-3.11.18-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8af2ef3b4b652ff109f98087242e2ab974b2b2b496304063585e3d78de0b000", size = 1678667, upload-time = "2025-04-21T09:42:11.741Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a8/04b6e11683a54e104b984bd19a9790eb1ae5f50968b601bb202d0406f0ff/aiohttp-3.11.18-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28c3f975e5ae3dbcbe95b7e3dcd30e51da561a0a0f2cfbcdea30fc1308d72137", size = 1601592, upload-time = "2025-04-21T09:42:14.137Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/9d/c33305ae8370b789423623f0e073d09ac775cd9c831ac0f11338b81c16e0/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c28875e316c7b4c3e745172d882d8a5c835b11018e33432d281211af35794a93", size = 1621679, upload-time = "2025-04-21T09:42:16.056Z" },
-    { url = "https://files.pythonhosted.org/packages/56/45/8e9a27fff0538173d47ba60362823358f7a5f1653c6c30c613469f94150e/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:13cd38515568ae230e1ef6919e2e33da5d0f46862943fcda74e7e915096815f3", size = 1656878, upload-time = "2025-04-21T09:42:18.368Z" },
-    { url = "https://files.pythonhosted.org/packages/84/5b/8c5378f10d7a5a46b10cb9161a3aac3eeae6dba54ec0f627fc4ddc4f2e72/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0e2a92101efb9f4c2942252c69c63ddb26d20f46f540c239ccfa5af865197bb8", size = 1620509, upload-time = "2025-04-21T09:42:20.141Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/2f/99dee7bd91c62c5ff0aa3c55f4ae7e1bc99c6affef780d7777c60c5b3735/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e6d3e32b8753c8d45ac550b11a1090dd66d110d4ef805ffe60fa61495360b3b2", size = 1680263, upload-time = "2025-04-21T09:42:21.993Z" },
-    { url = "https://files.pythonhosted.org/packages/03/0a/378745e4ff88acb83e2d5c884a4fe993a6e9f04600a4560ce0e9b19936e3/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ea4cf2488156e0f281f93cc2fd365025efcba3e2d217cbe3df2840f8c73db261", size = 1715014, upload-time = "2025-04-21T09:42:23.87Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/0b/b5524b3bb4b01e91bc4323aad0c2fcaebdf2f1b4d2eb22743948ba364958/aiohttp-3.11.18-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d4df95ad522c53f2b9ebc07f12ccd2cb15550941e11a5bbc5ddca2ca56316d7", size = 1666614, upload-time = "2025-04-21T09:42:25.764Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/b7/3d7b036d5a4ed5a4c704e0754afe2eef24a824dfab08e6efbffb0f6dd36a/aiohttp-3.11.18-cp313-cp313-win32.whl", hash = "sha256:cdd1bbaf1e61f0d94aced116d6e95fe25942f7a5f42382195fd9501089db5d78", size = 411358, upload-time = "2025-04-21T09:42:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/3c/143831b32cd23b5263a995b2a1794e10aa42f8a895aae5074c20fda36c07/aiohttp-3.11.18-cp313-cp313-win_amd64.whl", hash = "sha256:bdd619c27e44382cf642223f11cfd4d795161362a5a1fc1fa3940397bc89db01", size = 437658, upload-time = "2025-04-21T09:42:29.209Z" },
-]
-
-[[package]]
-name = "aiosignal"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "frozenlist" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b5/6d55e80f6d8a08ce22b982eafa278d823b541c925f11ee774b0b9c43473d/aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54", size = 19424, upload-time = "2024-12-13T17:10:40.86Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5", size = 7597, upload-time = "2024-12-13T17:10:38.469Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -79,81 +25,33 @@ wheels = [
 ]
 
 [[package]]
-name = "attrs"
-version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
-]
-
-[[package]]
-name = "audioop-lts"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/3b/69ff8a885e4c1c42014c2765275c4bd91fe7bc9847e9d8543dbcbb09f820/audioop_lts-0.2.1.tar.gz", hash = "sha256:e81268da0baa880431b68b1308ab7257eb33f356e57a5f9b1f915dfb13dd1387", size = 30204, upload-time = "2024-08-04T21:14:43.957Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/91/a219253cc6e92db2ebeaf5cf8197f71d995df6f6b16091d1f3ce62cb169d/audioop_lts-0.2.1-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd1345ae99e17e6910f47ce7d52673c6a1a70820d78b67de1b7abb3af29c426a", size = 46252, upload-time = "2024-08-04T21:13:56.209Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f6/3cb21e0accd9e112d27cee3b1477cd04dafe88675c54ad8b0d56226c1e0b/audioop_lts-0.2.1-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:e175350da05d2087e12cea8e72a70a1a8b14a17e92ed2022952a4419689ede5e", size = 27183, upload-time = "2024-08-04T21:13:59.966Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7e/f94c8a6a8b2571694375b4cf94d3e5e0f529e8e6ba280fad4d8c70621f27/audioop_lts-0.2.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:4a8dd6a81770f6ecf019c4b6d659e000dc26571b273953cef7cd1d5ce2ff3ae6", size = 26726, upload-time = "2024-08-04T21:14:00.846Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/f8/a0e8e7a033b03fae2b16bc5aa48100b461c4f3a8a38af56d5ad579924a3a/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cd3c0b6f2ca25c7d2b1c3adeecbe23e65689839ba73331ebc7d893fcda7ffe", size = 80718, upload-time = "2024-08-04T21:14:01.989Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/ea/a98ebd4ed631c93b8b8f2368862cd8084d75c77a697248c24437c36a6f7e/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff3f97b3372c97782e9c6d3d7fdbe83bce8f70de719605bd7ee1839cd1ab360a", size = 88326, upload-time = "2024-08-04T21:14:03.509Z" },
-    { url = "https://files.pythonhosted.org/packages/33/79/e97a9f9daac0982aa92db1199339bd393594d9a4196ad95ae088635a105f/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a351af79edefc2a1bd2234bfd8b339935f389209943043913a919df4b0f13300", size = 80539, upload-time = "2024-08-04T21:14:04.679Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d3/1051d80e6f2d6f4773f90c07e73743a1e19fcd31af58ff4e8ef0375d3a80/audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2aeb6f96f7f6da80354330470b9134d81b4cf544cdd1c549f2f45fe964d28059", size = 78577, upload-time = "2024-08-04T21:14:09.038Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/54f4c58bae8dc8c64a75071c7e98e105ddaca35449376fcb0180f6e3c9df/audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c589f06407e8340e81962575fcffbba1e92671879a221186c3d4662de9fe804e", size = 82074, upload-time = "2024-08-04T21:14:09.99Z" },
-    { url = "https://files.pythonhosted.org/packages/36/89/2e78daa7cebbea57e72c0e1927413be4db675548a537cfba6a19040d52fa/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fbae5d6925d7c26e712f0beda5ed69ebb40e14212c185d129b8dfbfcc335eb48", size = 84210, upload-time = "2024-08-04T21:14:11.468Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/57/3ff8a74df2ec2fa6d2ae06ac86e4a27d6412dbb7d0e0d41024222744c7e0/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_i686.whl", hash = "sha256:d2d5434717f33117f29b5691fbdf142d36573d751716249a288fbb96ba26a281", size = 85664, upload-time = "2024-08-04T21:14:12.394Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/21cc4e5878f6edbc8e54be4c108d7cb9cb6202313cfe98e4ece6064580dd/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f626a01c0a186b08f7ff61431c01c055961ee28769591efa8800beadd27a2959", size = 93255, upload-time = "2024-08-04T21:14:13.707Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/28/7f7418c362a899ac3b0bf13b1fde2d4ffccfdeb6a859abd26f2d142a1d58/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:05da64e73837f88ee5c6217d732d2584cf638003ac72df124740460531e95e47", size = 87760, upload-time = "2024-08-04T21:14:14.74Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d8/577a8be87dc7dd2ba568895045cee7d32e81d85a7e44a29000fe02c4d9d4/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:56b7a0a4dba8e353436f31a932f3045d108a67b5943b30f85a5563f4d8488d77", size = 84992, upload-time = "2024-08-04T21:14:19.155Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/9a/4699b0c4fcf89936d2bfb5425f55f1a8b86dff4237cfcc104946c9cd9858/audioop_lts-0.2.1-cp313-abi3-win32.whl", hash = "sha256:6e899eb8874dc2413b11926b5fb3857ec0ab55222840e38016a6ba2ea9b7d5e3", size = 26059, upload-time = "2024-08-04T21:14:20.438Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/1c/1f88e9c5dd4785a547ce5fd1eb83fff832c00cc0e15c04c1119b02582d06/audioop_lts-0.2.1-cp313-abi3-win_amd64.whl", hash = "sha256:64562c5c771fb0a8b6262829b9b4f37a7b886c01b4d3ecdbae1d629717db08b4", size = 30412, upload-time = "2024-08-04T21:14:21.342Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e9/c123fd29d89a6402ad261516f848437472ccc602abb59bba522af45e281b/audioop_lts-0.2.1-cp313-abi3-win_arm64.whl", hash = "sha256:c45317debeb64002e980077642afbd977773a25fa3dfd7ed0c84dccfc1fafcb0", size = 23578, upload-time = "2024-08-04T21:14:22.193Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/99/bb664a99561fd4266687e5cb8965e6ec31ba4ff7002c3fce3dc5ef2709db/audioop_lts-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3827e3fce6fee4d69d96a3d00cd2ab07f3c0d844cb1e44e26f719b34a5b15455", size = 46827, upload-time = "2024-08-04T21:14:23.034Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e3/f664171e867e0768ab982715e744430cf323f1282eb2e11ebfb6ee4c4551/audioop_lts-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:161249db9343b3c9780ca92c0be0d1ccbfecdbccac6844f3d0d44b9c4a00a17f", size = 27479, upload-time = "2024-08-04T21:14:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/0d/2a79231ff54eb20e83b47e7610462ad6a2bea4e113fae5aa91c6547e7764/audioop_lts-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5b7b4ff9de7a44e0ad2618afdc2ac920b91f4a6d3509520ee65339d4acde5abf", size = 27056, upload-time = "2024-08-04T21:14:28.061Z" },
-    { url = "https://files.pythonhosted.org/packages/86/46/342471398283bb0634f5a6df947806a423ba74b2e29e250c7ec0e3720e4f/audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72e37f416adb43b0ced93419de0122b42753ee74e87070777b53c5d2241e7fab", size = 87802, upload-time = "2024-08-04T21:14:29.586Z" },
-    { url = "https://files.pythonhosted.org/packages/56/44/7a85b08d4ed55517634ff19ddfbd0af05bf8bfd39a204e4445cd0e6f0cc9/audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:534ce808e6bab6adb65548723c8cbe189a3379245db89b9d555c4210b4aaa9b6", size = 95016, upload-time = "2024-08-04T21:14:30.481Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2a/45edbca97ea9ee9e6bbbdb8d25613a36e16a4d1e14ae01557392f15cc8d3/audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2de9b6fb8b1cf9f03990b299a9112bfdf8b86b6987003ca9e8a6c4f56d39543", size = 87394, upload-time = "2024-08-04T21:14:31.883Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ae/832bcbbef2c510629593bf46739374174606e25ac7d106b08d396b74c964/audioop_lts-0.2.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f24865991b5ed4b038add5edbf424639d1358144f4e2a3e7a84bc6ba23e35074", size = 84874, upload-time = "2024-08-04T21:14:32.751Z" },
-    { url = "https://files.pythonhosted.org/packages/26/1c/8023c3490798ed2f90dfe58ec3b26d7520a243ae9c0fc751ed3c9d8dbb69/audioop_lts-0.2.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bdb3b7912ccd57ea53197943f1bbc67262dcf29802c4a6df79ec1c715d45a78", size = 88698, upload-time = "2024-08-04T21:14:34.147Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/db/5379d953d4918278b1f04a5a64b2c112bd7aae8f81021009da0dcb77173c/audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:120678b208cca1158f0a12d667af592e067f7a50df9adc4dc8f6ad8d065a93fb", size = 90401, upload-time = "2024-08-04T21:14:35.276Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6e/3c45d316705ab1aec2e69543a5b5e458d0d112a93d08994347fafef03d50/audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:54cd4520fc830b23c7d223693ed3e1b4d464997dd3abc7c15dce9a1f9bd76ab2", size = 91864, upload-time = "2024-08-04T21:14:36.158Z" },
-    { url = "https://files.pythonhosted.org/packages/08/58/6a371d8fed4f34debdb532c0b00942a84ebf3e7ad368e5edc26931d0e251/audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:d6bd20c7a10abcb0fb3d8aaa7508c0bf3d40dfad7515c572014da4b979d3310a", size = 98796, upload-time = "2024-08-04T21:14:37.185Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/77/d637aa35497e0034ff846fd3330d1db26bc6fd9dd79c406e1341188b06a2/audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:f0ed1ad9bd862539ea875fb339ecb18fcc4148f8d9908f4502df28f94d23491a", size = 94116, upload-time = "2024-08-04T21:14:38.145Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/60/7afc2abf46bbcf525a6ebc0305d85ab08dc2d1e2da72c48dbb35eee5b62c/audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e1af3ff32b8c38a7d900382646e91f2fc515fd19dea37e9392275a5cbfdbff63", size = 91520, upload-time = "2024-08-04T21:14:39.128Z" },
-    { url = "https://files.pythonhosted.org/packages/65/6d/42d40da100be1afb661fd77c2b1c0dfab08af1540df57533621aea3db52a/audioop_lts-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:f51bb55122a89f7a0817d7ac2319744b4640b5b446c4c3efcea5764ea99ae509", size = 26482, upload-time = "2024-08-04T21:14:40.269Z" },
-    { url = "https://files.pythonhosted.org/packages/01/09/f08494dca79f65212f5b273aecc5a2f96691bf3307cac29acfcf84300c01/audioop_lts-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f0f2f336aa2aee2bce0b0dcc32bbba9178995454c7b979cf6ce086a8801e14c7", size = 30780, upload-time = "2024-08-04T21:14:41.128Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/35/be73b6015511aa0173ec595fc579133b797ad532996f2998fd6b8d1bbe6b/audioop_lts-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:78bfb3703388c780edf900be66e07de5a3d4105ca8e8720c5c4d67927e0b15d0", size = 23918, upload-time = "2024-08-04T21:14:42.803Z" },
-]
-
-[[package]]
 name = "cartesia"
-version = "2.0.17"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "audioop-lts", marker = "python_full_version < '4'" },
+    { name = "anyio" },
+    { name = "distro" },
     { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "iterators" },
     { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "pydub" },
+    { name = "sniffio" },
     { name = "typing-extensions" },
-    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/ff/bfd3191a7fdbbb5c4dfe4d34461c6aa0d158a6eea599cb9a5df2c91109fa/cartesia-2.0.17.tar.gz", hash = "sha256:fd7fcdcbb5aac47ff6b35cd48420b4993ef1742aaa71bb7d52b335314045d584", size = 79227, upload-time = "2025-11-13T21:06:45.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/03/fcbb885bc08187d26791206ce67ac469ce1ae256b8f822609a32f1055084/cartesia-3.2.0.tar.gz", hash = "sha256:5d7f627b17c75ed216052d02ee27101a33753c34a8c2c3537217f2ee682b50ac", size = 333356, upload-time = "2026-05-28T05:26:04.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/9c/f7b83329e0567d0ab165abd81405108d146abc9728732c1af3858ee38bfd/cartesia-2.0.17-py3-none-any.whl", hash = "sha256:de8975ced1c5c09f1b51bb87ceea6c1641ba817901cfc73c47fc4e37c6ca351a", size = 153376, upload-time = "2025-11-13T21:06:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/46/56ab5977716823edad34cbe4f7238392ede3e8f0615352d412aae6d36d7d/cartesia-3.2.0-py3-none-any.whl", hash = "sha256:982d3cbfce4098318ba58bea13766572ed0b1bb1d4f88f3d025fd13baadcd26f", size = 210659, upload-time = "2026-05-28T05:26:05.707Z" },
+]
+
+[package.optional-dependencies]
+websockets = [
+    { name = "websockets" },
 ]
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.4.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
-    { name = "cartesia" },
+    { name = "cartesia", extra = ["websockets"] },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
 ]
@@ -165,7 +63,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", specifier = ">=2.0.17,<3.0.0" },
+    { name = "cartesia", extras = ["websockets"], specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.7.1" },
 ]
@@ -204,46 +102,12 @@ wheels = [
 ]
 
 [[package]]
-name = "frozenlist"
-version = "1.6.0"
+name = "distro"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/f4/d744cba2da59b5c1d88823cf9e8a6c74e4659e2b27604ed973be2a0bf5ab/frozenlist-1.6.0.tar.gz", hash = "sha256:b99655c32c1c8e06d111e7f41c06c29a5318cb1835df23a45518e02a47c63b68", size = 42831, upload-time = "2025-04-17T22:38:53.099Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/e5/04c7090c514d96ca00887932417f04343ab94904a56ab7f57861bf63652d/frozenlist-1.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1d7fb014fe0fbfee3efd6a94fc635aeaa68e5e1720fe9e57357f2e2c6e1a647e", size = 158182, upload-time = "2025-04-17T22:37:16.837Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/8f/60d0555c61eec855783a6356268314d204137f5e0c53b59ae2fc28938c99/frozenlist-1.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:01bcaa305a0fdad12745502bfd16a1c75b14558dabae226852f9159364573117", size = 122838, upload-time = "2025-04-17T22:37:18.352Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a7/d0ec890e3665b4b3b7c05dc80e477ed8dc2e2e77719368e78e2cd9fec9c8/frozenlist-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b314faa3051a6d45da196a2c495e922f987dc848e967d8cfeaee8a0328b1cd4", size = 120980, upload-time = "2025-04-17T22:37:19.857Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/19/9b355a5e7a8eba903a008579964192c3e427444752f20b2144b10bb336df/frozenlist-1.6.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da62fecac21a3ee10463d153549d8db87549a5e77eefb8c91ac84bb42bb1e4e3", size = 305463, upload-time = "2025-04-17T22:37:21.328Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8d/5b4c758c2550131d66935ef2fa700ada2461c08866aef4229ae1554b93ca/frozenlist-1.6.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1eb89bf3454e2132e046f9599fbcf0a4483ed43b40f545551a39316d0201cd1", size = 297985, upload-time = "2025-04-17T22:37:23.55Z" },
-    { url = "https://files.pythonhosted.org/packages/48/2c/537ec09e032b5865715726b2d1d9813e6589b571d34d01550c7aeaad7e53/frozenlist-1.6.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18689b40cb3936acd971f663ccb8e2589c45db5e2c5f07e0ec6207664029a9c", size = 311188, upload-time = "2025-04-17T22:37:25.221Z" },
-    { url = "https://files.pythonhosted.org/packages/31/2f/1aa74b33f74d54817055de9a4961eff798f066cdc6f67591905d4fc82a84/frozenlist-1.6.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e67ddb0749ed066b1a03fba812e2dcae791dd50e5da03be50b6a14d0c1a9ee45", size = 311874, upload-time = "2025-04-17T22:37:26.791Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f0/cfec18838f13ebf4b37cfebc8649db5ea71a1b25dacd691444a10729776c/frozenlist-1.6.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc5e64626e6682638d6e44398c9baf1d6ce6bc236d40b4b57255c9d3f9761f1f", size = 291897, upload-time = "2025-04-17T22:37:28.958Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a5/deb39325cbbea6cd0a46db8ccd76150ae2fcbe60d63243d9df4a0b8c3205/frozenlist-1.6.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:437cfd39564744ae32ad5929e55b18ebd88817f9180e4cc05e7d53b75f79ce85", size = 305799, upload-time = "2025-04-17T22:37:30.889Z" },
-    { url = "https://files.pythonhosted.org/packages/78/22/6ddec55c5243a59f605e4280f10cee8c95a449f81e40117163383829c241/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:62dd7df78e74d924952e2feb7357d826af8d2f307557a779d14ddf94d7311be8", size = 302804, upload-time = "2025-04-17T22:37:32.489Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b7/d9ca9bab87f28855063c4d202936800219e39db9e46f9fb004d521152623/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:a66781d7e4cddcbbcfd64de3d41a61d6bdde370fc2e38623f30b2bd539e84a9f", size = 316404, upload-time = "2025-04-17T22:37:34.59Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3a/1255305db7874d0b9eddb4fe4a27469e1fb63720f1fc6d325a5118492d18/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:482fe06e9a3fffbcd41950f9d890034b4a54395c60b5e61fae875d37a699813f", size = 295572, upload-time = "2025-04-17T22:37:36.337Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/f2/8d38eeee39a0e3a91b75867cc102159ecccf441deb6ddf67be96d3410b84/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e4f9373c500dfc02feea39f7a56e4f543e670212102cc2eeb51d3a99c7ffbde6", size = 307601, upload-time = "2025-04-17T22:37:37.923Z" },
-    { url = "https://files.pythonhosted.org/packages/38/04/80ec8e6b92f61ef085422d7b196822820404f940950dde5b2e367bede8bc/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:e69bb81de06827147b7bfbaeb284d85219fa92d9f097e32cc73675f279d70188", size = 314232, upload-time = "2025-04-17T22:37:39.669Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/58/93b41fb23e75f38f453ae92a2f987274c64637c450285577bd81c599b715/frozenlist-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7613d9977d2ab4a9141dde4a149f4357e4065949674c5649f920fec86ecb393e", size = 308187, upload-time = "2025-04-17T22:37:41.662Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a2/e64df5c5aa36ab3dee5a40d254f3e471bb0603c225f81664267281c46a2d/frozenlist-1.6.0-cp313-cp313-win32.whl", hash = "sha256:4def87ef6d90429f777c9d9de3961679abf938cb6b7b63d4a7eb8a268babfce4", size = 114772, upload-time = "2025-04-17T22:37:43.132Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/77/fead27441e749b2d574bb73d693530d59d520d4b9e9679b8e3cb779d37f2/frozenlist-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:37a8a52c3dfff01515e9bbbee0e6063181362f9de3db2ccf9bc96189b557cbfd", size = 119847, upload-time = "2025-04-17T22:37:45.118Z" },
-    { url = "https://files.pythonhosted.org/packages/df/bd/cc6d934991c1e5d9cafda83dfdc52f987c7b28343686aef2e58a9cf89f20/frozenlist-1.6.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46138f5a0773d064ff663d273b309b696293d7a7c00a0994c5c13a5078134b64", size = 174937, upload-time = "2025-04-17T22:37:46.635Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a2/daf945f335abdbfdd5993e9dc348ef4507436936ab3c26d7cfe72f4843bf/frozenlist-1.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f88bc0a2b9c2a835cb888b32246c27cdab5740059fb3688852bf91e915399b91", size = 136029, upload-time = "2025-04-17T22:37:48.192Z" },
-    { url = "https://files.pythonhosted.org/packages/51/65/4c3145f237a31247c3429e1c94c384d053f69b52110a0d04bfc8afc55fb2/frozenlist-1.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:777704c1d7655b802c7850255639672e90e81ad6fa42b99ce5ed3fbf45e338dd", size = 134831, upload-time = "2025-04-17T22:37:50.485Z" },
-    { url = "https://files.pythonhosted.org/packages/77/38/03d316507d8dea84dfb99bdd515ea245628af964b2bf57759e3c9205cc5e/frozenlist-1.6.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85ef8d41764c7de0dcdaf64f733a27352248493a85a80661f3c678acd27e31f2", size = 392981, upload-time = "2025-04-17T22:37:52.558Z" },
-    { url = "https://files.pythonhosted.org/packages/37/02/46285ef9828f318ba400a51d5bb616ded38db8466836a9cfa39f3903260b/frozenlist-1.6.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:da5cb36623f2b846fb25009d9d9215322318ff1c63403075f812b3b2876c8506", size = 371999, upload-time = "2025-04-17T22:37:54.092Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/64/1212fea37a112c3c5c05bfb5f0a81af4836ce349e69be75af93f99644da9/frozenlist-1.6.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cbb56587a16cf0fb8acd19e90ff9924979ac1431baea8681712716a8337577b0", size = 392200, upload-time = "2025-04-17T22:37:55.951Z" },
-    { url = "https://files.pythonhosted.org/packages/81/ce/9a6ea1763e3366e44a5208f76bf37c76c5da570772375e4d0be85180e588/frozenlist-1.6.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6154c3ba59cda3f954c6333025369e42c3acd0c6e8b6ce31eb5c5b8116c07e0", size = 390134, upload-time = "2025-04-17T22:37:57.633Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/939738b0b495b2c6d0c39ba51563e453232813042a8d908b8f9544296c29/frozenlist-1.6.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e8246877afa3f1ae5c979fe85f567d220f86a50dc6c493b9b7d8191181ae01e", size = 365208, upload-time = "2025-04-17T22:37:59.742Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/8b/939e62e93c63409949c25220d1ba8e88e3960f8ef6a8d9ede8f94b459d27/frozenlist-1.6.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0f6cce16306d2e117cf9db71ab3a9e8878a28176aeaf0dbe35248d97b28d0c", size = 385548, upload-time = "2025-04-17T22:38:01.416Z" },
-    { url = "https://files.pythonhosted.org/packages/62/38/22d2873c90102e06a7c5a3a5b82ca47e393c6079413e8a75c72bff067fa8/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1b8e8cd8032ba266f91136d7105706ad57770f3522eac4a111d77ac126a25a9b", size = 391123, upload-time = "2025-04-17T22:38:03.049Z" },
-    { url = "https://files.pythonhosted.org/packages/44/78/63aaaf533ee0701549500f6d819be092c6065cb5c577edb70c09df74d5d0/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e2ada1d8515d3ea5378c018a5f6d14b4994d4036591a52ceaf1a1549dec8e1ad", size = 394199, upload-time = "2025-04-17T22:38:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/54/45/71a6b48981d429e8fbcc08454dc99c4c2639865a646d549812883e9c9dd3/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:cdb2c7f071e4026c19a3e32b93a09e59b12000751fc9b0b7758da899e657d215", size = 373854, upload-time = "2025-04-17T22:38:06.576Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f3/dbf2a5e11736ea81a66e37288bf9f881143a7822b288a992579ba1b4204d/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:03572933a1969a6d6ab509d509e5af82ef80d4a5d4e1e9f2e1cdd22c77a3f4d2", size = 395412, upload-time = "2025-04-17T22:38:08.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/f1/c63166806b331f05104d8ea385c4acd511598568b1f3e4e8297ca54f2676/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:77effc978947548b676c54bbd6a08992759ea6f410d4987d69feea9cd0919911", size = 394936, upload-time = "2025-04-17T22:38:10.056Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/ea/4f3e69e179a430473eaa1a75ff986526571215fefc6b9281cdc1f09a4eb8/frozenlist-1.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a2bda8be77660ad4089caf2223fdbd6db1858462c4b85b67fbfa22102021e497", size = 391459, upload-time = "2025-04-17T22:38:11.826Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/c3/0fc2c97dea550df9afd072a37c1e95421652e3206bbeaa02378b24c2b480/frozenlist-1.6.0-cp313-cp313t-win32.whl", hash = "sha256:a4d96dc5bcdbd834ec6b0f91027817214216b5b30316494d2b1aebffb87c534f", size = 128797, upload-time = "2025-04-17T22:38:14.013Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f5/79c9320c5656b1965634fe4be9c82b12a3305bdbc58ad9cb941131107b20/frozenlist-1.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e18036cb4caa17ea151fd5f3d70be9d354c99eb8cf817a3ccde8a7873b074348", size = 134709, upload-time = "2025-04-17T22:38:15.551Z" },
-    { url = "https://files.pythonhosted.org/packages/71/3e/b04a0adda73bd52b390d730071c0d577073d3d26740ee1bad25c3ad0f37b/frozenlist-1.6.0-py3-none-any.whl", hash = "sha256:535eec9987adb04701266b92745d6cdcef2e77669299359c3009c3404dd5d191", size = 12404, upload-time = "2025-04-17T22:38:51.668Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -311,15 +175,6 @@ wheels = [
 ]
 
 [[package]]
-name = "iterators"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/c4/135b5bdb9f14f728fe1274361b336f77c5f1606af9a5622a765fe75f5fa0/iterators-0.2.0.tar.gz", hash = "sha256:e9927a1ea1ef081830fd1512f3916857c36bd4b37272819a6cd29d0f44431b97", size = 4284, upload-time = "2023-01-23T16:07:02.46Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/a1/9c29772ac9f3bdf9837c92ba5c1fc93f75da14c2e0c3fc41e10485f68feb/iterators-0.2.0-py3-none-any.whl", hash = "sha256:1d7ff03f576c9de0e01bac66209556c066d6b1fc45583a99cfc9f4645be7900e", size = 5022, upload-time = "2023-01-23T16:07:00.352Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -367,49 +222,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multidict"
-version = "6.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/2c/e367dfb4c6538614a0c9453e510d75d66099edf1c4e69da1b5ce691a1931/multidict-6.4.3.tar.gz", hash = "sha256:3ada0b058c9f213c5f95ba301f922d402ac234f1111a7d8fd70f1b99f3c281ec", size = 89372, upload-time = "2025-04-10T22:20:17.956Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/4b/86fd786d03915c6f49998cf10cd5fe6b6ac9e9a071cb40885d2e080fb90d/multidict-6.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7a76534263d03ae0cfa721fea40fd2b5b9d17a6f85e98025931d41dc49504474", size = 63831, upload-time = "2025-04-10T22:18:48.748Z" },
-    { url = "https://files.pythonhosted.org/packages/45/05/9b51fdf7aef2563340a93be0a663acba2c428c4daeaf3960d92d53a4a930/multidict-6.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:805031c2f599eee62ac579843555ed1ce389ae00c7e9f74c2a1b45e0564a88dd", size = 37888, upload-time = "2025-04-10T22:18:50.021Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/53fc25394386c911822419b522181227ca450cf57fea76e6188772a1bd91/multidict-6.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c56c179839d5dcf51d565132185409d1d5dd8e614ba501eb79023a6cab25576b", size = 36852, upload-time = "2025-04-10T22:18:51.246Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/68/7b99c751e822467c94a235b810a2fd4047d4ecb91caef6b5c60116991c4b/multidict-6.4.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c64f4ddb3886dd8ab71b68a7431ad4aa01a8fa5be5b11543b29674f29ca0ba3", size = 223644, upload-time = "2025-04-10T22:18:52.965Z" },
-    { url = "https://files.pythonhosted.org/packages/80/1b/d458d791e4dd0f7e92596667784fbf99e5c8ba040affe1ca04f06b93ae92/multidict-6.4.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3002a856367c0b41cad6784f5b8d3ab008eda194ed7864aaa58f65312e2abcac", size = 230446, upload-time = "2025-04-10T22:18:54.509Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/46/9793378d988905491a7806d8987862dc5a0bae8a622dd896c4008c7b226b/multidict-6.4.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d75e621e7d887d539d6e1d789f0c64271c250276c333480a9e1de089611f790", size = 231070, upload-time = "2025-04-10T22:18:56.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b8/b127d3e1f8dd2a5bf286b47b24567ae6363017292dc6dec44656e6246498/multidict-6.4.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:995015cf4a3c0d72cbf453b10a999b92c5629eaf3a0c3e1efb4b5c1f602253bb", size = 229956, upload-time = "2025-04-10T22:18:59.146Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/93/f70a4c35b103fcfe1443059a2bb7f66e5c35f2aea7804105ff214f566009/multidict-6.4.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2b0fabae7939d09d7d16a711468c385272fa1b9b7fb0d37e51143585d8e72e0", size = 222599, upload-time = "2025-04-10T22:19:00.657Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8c/e28e0eb2fe34921d6aa32bfc4ac75b09570b4d6818cc95d25499fe08dc1d/multidict-6.4.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:61ed4d82f8a1e67eb9eb04f8587970d78fe7cddb4e4d6230b77eda23d27938f9", size = 216136, upload-time = "2025-04-10T22:19:02.244Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f5/fbc81f866585b05f89f99d108be5d6ad170e3b6c4d0723d1a2f6ba5fa918/multidict-6.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:062428944a8dc69df9fdc5d5fc6279421e5f9c75a9ee3f586f274ba7b05ab3c8", size = 228139, upload-time = "2025-04-10T22:19:04.151Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ba/7d196bad6b85af2307d81f6979c36ed9665f49626f66d883d6c64d156f78/multidict-6.4.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b90e27b4674e6c405ad6c64e515a505c6d113b832df52fdacb6b1ffd1fa9a1d1", size = 226251, upload-time = "2025-04-10T22:19:06.117Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/e2/fae46a370dce79d08b672422a33df721ec8b80105e0ea8d87215ff6b090d/multidict-6.4.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7d50d4abf6729921e9613d98344b74241572b751c6b37feed75fb0c37bd5a817", size = 221868, upload-time = "2025-04-10T22:19:07.981Z" },
-    { url = "https://files.pythonhosted.org/packages/26/20/bbc9a3dec19d5492f54a167f08546656e7aef75d181d3d82541463450e88/multidict-6.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:43fe10524fb0a0514be3954be53258e61d87341008ce4914f8e8b92bee6f875d", size = 233106, upload-time = "2025-04-10T22:19:09.5Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8d/f30ae8f5ff7a2461177f4d8eb0d8f69f27fb6cfe276b54ec4fd5a282d918/multidict-6.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:236966ca6c472ea4e2d3f02f6673ebfd36ba3f23159c323f5a496869bc8e47c9", size = 230163, upload-time = "2025-04-10T22:19:11Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e9/2833f3c218d3c2179f3093f766940ded6b81a49d2e2f9c46ab240d23dfec/multidict-6.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:422a5ec315018e606473ba1f5431e064cf8b2a7468019233dcf8082fabad64c8", size = 225906, upload-time = "2025-04-10T22:19:12.875Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/31/6edab296ac369fd286b845fa5dd4c409e63bc4655ed8c9510fcb477e9ae9/multidict-6.4.3-cp313-cp313-win32.whl", hash = "sha256:f901a5aace8e8c25d78960dcc24c870c8d356660d3b49b93a78bf38eb682aac3", size = 35238, upload-time = "2025-04-10T22:19:14.41Z" },
-    { url = "https://files.pythonhosted.org/packages/23/57/2c0167a1bffa30d9a1383c3dab99d8caae985defc8636934b5668830d2ef/multidict-6.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:1c152c49e42277bc9a2f7b78bd5fa10b13e88d1b0328221e7aef89d5c60a99a5", size = 38799, upload-time = "2025-04-10T22:19:15.869Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/13/2ead63b9ab0d2b3080819268acb297bd66e238070aa8d42af12b08cbee1c/multidict-6.4.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:be8751869e28b9c0d368d94f5afcb4234db66fe8496144547b4b6d6a0645cfc6", size = 68642, upload-time = "2025-04-10T22:19:17.527Z" },
-    { url = "https://files.pythonhosted.org/packages/85/45/f1a751e1eede30c23951e2ae274ce8fad738e8a3d5714be73e0a41b27b16/multidict-6.4.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d4b31f8a68dccbcd2c0ea04f0e014f1defc6b78f0eb8b35f2265e8716a6df0c", size = 40028, upload-time = "2025-04-10T22:19:19.465Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/29/fcc53e886a2cc5595cc4560df333cb9630257bda65003a7eb4e4e0d8f9c1/multidict-6.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756", size = 39424, upload-time = "2025-04-10T22:19:20.762Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/056c81119d8b88703971f937b371795cab1407cd3c751482de5bfe1a04a9/multidict-6.4.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e78006af1a7c8a8007e4f56629d7252668344442f66982368ac06522445e375", size = 226178, upload-time = "2025-04-10T22:19:22.17Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/79/3b7e5fea0aa80583d3a69c9d98b7913dfd4fbc341fb10bb2fb48d35a9c21/multidict-6.4.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:daeac9dd30cda8703c417e4fddccd7c4dc0c73421a0b54a7da2713be125846be", size = 222617, upload-time = "2025-04-10T22:19:23.773Z" },
-    { url = "https://files.pythonhosted.org/packages/06/db/3ed012b163e376fc461e1d6a67de69b408339bc31dc83d39ae9ec3bf9578/multidict-6.4.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f6f90700881438953eae443a9c6f8a509808bc3b185246992c4233ccee37fea", size = 227919, upload-time = "2025-04-10T22:19:25.35Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/db/0433c104bca380989bc04d3b841fc83e95ce0c89f680e9ea4251118b52b6/multidict-6.4.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f84627997008390dd15762128dcf73c3365f4ec0106739cde6c20a07ed198ec8", size = 226097, upload-time = "2025-04-10T22:19:27.183Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/910db2618175724dd254b7ae635b6cd8d2947a8b76b0376de7b96d814dab/multidict-6.4.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3307b48cd156153b117c0ea54890a3bdbf858a5b296ddd40dc3852e5f16e9b02", size = 220706, upload-time = "2025-04-10T22:19:28.882Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/aa176c6f5f1d901aac957d5258d5e22897fe13948d1e69063ae3d5d0ca01/multidict-6.4.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ead46b0fa1dcf5af503a46e9f1c2e80b5d95c6011526352fa5f42ea201526124", size = 211728, upload-time = "2025-04-10T22:19:30.481Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/42/d51cc5fc1527c3717d7f85137d6c79bb7a93cd214c26f1fc57523774dbb5/multidict-6.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1748cb2743bedc339d63eb1bca314061568793acd603a6e37b09a326334c9f44", size = 226276, upload-time = "2025-04-10T22:19:32.454Z" },
-    { url = "https://files.pythonhosted.org/packages/28/6b/d836dea45e0b8432343ba4acf9a8ecaa245da4c0960fb7ab45088a5e568a/multidict-6.4.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:acc9fa606f76fc111b4569348cc23a771cb52c61516dcc6bcef46d612edb483b", size = 212069, upload-time = "2025-04-10T22:19:34.17Z" },
-    { url = "https://files.pythonhosted.org/packages/55/34/0ee1a7adb3560e18ee9289c6e5f7db54edc312b13e5c8263e88ea373d12c/multidict-6.4.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:31469d5832b5885adeb70982e531ce86f8c992334edd2f2254a10fa3182ac504", size = 217858, upload-time = "2025-04-10T22:19:35.879Z" },
-    { url = "https://files.pythonhosted.org/packages/04/08/586d652c2f5acefe0cf4e658eedb4d71d4ba6dfd4f189bd81b400fc1bc6b/multidict-6.4.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ba46b51b6e51b4ef7bfb84b82f5db0dc5e300fb222a8a13b8cd4111898a869cf", size = 226988, upload-time = "2025-04-10T22:19:37.434Z" },
-    { url = "https://files.pythonhosted.org/packages/82/e3/cc59c7e2bc49d7f906fb4ffb6d9c3a3cf21b9f2dd9c96d05bef89c2b1fd1/multidict-6.4.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:389cfefb599edf3fcfd5f64c0410da686f90f5f5e2c4d84e14f6797a5a337af4", size = 220435, upload-time = "2025-04-10T22:19:39.005Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/32/5c3a556118aca9981d883f38c4b1bfae646f3627157f70f4068e5a648955/multidict-6.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:64bc2bbc5fba7b9db5c2c8d750824f41c6994e3882e6d73c903c2afa78d091e4", size = 221494, upload-time = "2025-04-10T22:19:41.447Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/3b/1599631f59024b75c4d6e3069f4502409970a336647502aaf6b62fb7ac98/multidict-6.4.3-cp313-cp313t-win32.whl", hash = "sha256:0ecdc12ea44bab2807d6b4a7e5eef25109ab1c82a8240d86d3c1fc9f3b72efd5", size = 41775, upload-time = "2025-04-10T22:19:43.707Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/4e/09301668d675d02ca8e8e1a3e6be046619e30403f5ada2ed5b080ae28d02/multidict-6.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7146a8742ea71b5d7d955bffcef58a9e6e04efba704b52a460134fefd10a8208", size = 45946, upload-time = "2025-04-10T22:19:45.071Z" },
-    { url = "https://files.pythonhosted.org/packages/96/10/7d526c8974f017f1e7ca584c71ee62a638e9334d8d33f27d7cdfc9ae79e4/multidict-6.4.3-py3-none-any.whl", hash = "sha256:59fe01ee8e2a1e8ceb3f6dbb216b09c8d9f4ef1c22c4fc825d045a147fa2ebc9", size = 10400, upload-time = "2025-04-10T22:20:16.445Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -425,47 +237,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "propcache"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/c8/fdc6686a986feae3541ea23dcaa661bd93972d3940460646c6bb96e21c40/propcache-0.3.1.tar.gz", hash = "sha256:40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf", size = 43651, upload-time = "2025-03-26T03:06:12.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/60/f645cc8b570f99be3cf46714170c2de4b4c9d6b827b912811eff1eb8a412/propcache-0.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f1528ec4374617a7a753f90f20e2f551121bb558fcb35926f99e3c42367164b8", size = 77865, upload-time = "2025-03-26T03:04:53.406Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d4/c1adbf3901537582e65cf90fd9c26fde1298fde5a2c593f987112c0d0798/propcache-0.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dc1915ec523b3b494933b5424980831b636fe483d7d543f7afb7b3bf00f0c10f", size = 45452, upload-time = "2025-03-26T03:04:54.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b5/fe752b2e63f49f727c6c1c224175d21b7d1727ce1d4873ef1c24c9216830/propcache-0.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a110205022d077da24e60b3df8bcee73971be9575dec5573dd17ae5d81751111", size = 44800, upload-time = "2025-03-26T03:04:55.844Z" },
-    { url = "https://files.pythonhosted.org/packages/62/37/fc357e345bc1971e21f76597028b059c3d795c5ca7690d7a8d9a03c9708a/propcache-0.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d249609e547c04d190e820d0d4c8ca03ed4582bcf8e4e160a6969ddfb57b62e5", size = 225804, upload-time = "2025-03-26T03:04:57.158Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/f1/16e12c33e3dbe7f8b737809bad05719cff1dccb8df4dafbcff5575002c0e/propcache-0.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ced33d827625d0a589e831126ccb4f5c29dfdf6766cac441d23995a65825dcb", size = 230650, upload-time = "2025-03-26T03:04:58.61Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/a2/018b9f2ed876bf5091e60153f727e8f9073d97573f790ff7cdf6bc1d1fb8/propcache-0.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4114c4ada8f3181af20808bedb250da6bae56660e4b8dfd9cd95d4549c0962f7", size = 234235, upload-time = "2025-03-26T03:05:00.599Z" },
-    { url = "https://files.pythonhosted.org/packages/45/5f/3faee66fc930dfb5da509e34c6ac7128870631c0e3582987fad161fcb4b1/propcache-0.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:975af16f406ce48f1333ec5e912fe11064605d5c5b3f6746969077cc3adeb120", size = 228249, upload-time = "2025-03-26T03:05:02.11Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1e/a0d5ebda5da7ff34d2f5259a3e171a94be83c41eb1e7cd21a2105a84a02e/propcache-0.3.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a34aa3a1abc50740be6ac0ab9d594e274f59960d3ad253cd318af76b996dd654", size = 214964, upload-time = "2025-03-26T03:05:03.599Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a0/d72da3f61ceab126e9be1f3bc7844b4e98c6e61c985097474668e7e52152/propcache-0.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9cec3239c85ed15bfaded997773fdad9fb5662b0a7cbc854a43f291eb183179e", size = 222501, upload-time = "2025-03-26T03:05:05.107Z" },
-    { url = "https://files.pythonhosted.org/packages/18/6d/a008e07ad7b905011253adbbd97e5b5375c33f0b961355ca0a30377504ac/propcache-0.3.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:05543250deac8e61084234d5fc54f8ebd254e8f2b39a16b1dce48904f45b744b", size = 217917, upload-time = "2025-03-26T03:05:06.59Z" },
-    { url = "https://files.pythonhosted.org/packages/98/37/02c9343ffe59e590e0e56dc5c97d0da2b8b19fa747ebacf158310f97a79a/propcache-0.3.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5cb5918253912e088edbf023788de539219718d3b10aef334476b62d2b53de53", size = 217089, upload-time = "2025-03-26T03:05:08.1Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/d3406629a2c8a5666d4674c50f757a77be119b113eedd47b0375afdf1b42/propcache-0.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f3bbecd2f34d0e6d3c543fdb3b15d6b60dd69970c2b4c822379e5ec8f6f621d5", size = 228102, upload-time = "2025-03-26T03:05:09.982Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/a7/3664756cf50ce739e5f3abd48febc0be1a713b1f389a502ca819791a6b69/propcache-0.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aca63103895c7d960a5b9b044a83f544b233c95e0dcff114389d64d762017af7", size = 230122, upload-time = "2025-03-26T03:05:11.408Z" },
-    { url = "https://files.pythonhosted.org/packages/35/36/0bbabaacdcc26dac4f8139625e930f4311864251276033a52fd52ff2a274/propcache-0.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a0a9898fdb99bf11786265468571e628ba60af80dc3f6eb89a3545540c6b0ef", size = 226818, upload-time = "2025-03-26T03:05:12.909Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/27/4e0ef21084b53bd35d4dae1634b6d0bad35e9c58ed4f032511acca9d4d26/propcache-0.3.1-cp313-cp313-win32.whl", hash = "sha256:3a02a28095b5e63128bcae98eb59025924f121f048a62393db682f049bf4ac24", size = 40112, upload-time = "2025-03-26T03:05:14.289Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/2c/a54614d61895ba6dd7ac8f107e2b2a0347259ab29cbf2ecc7b94fa38c4dc/propcache-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:813fbb8b6aea2fc9659815e585e548fe706d6f663fa73dff59a1677d4595a037", size = 44034, upload-time = "2025-03-26T03:05:15.616Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a8/0a4fd2f664fc6acc66438370905124ce62e84e2e860f2557015ee4a61c7e/propcache-0.3.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a444192f20f5ce8a5e52761a031b90f5ea6288b1eef42ad4c7e64fef33540b8f", size = 82613, upload-time = "2025-03-26T03:05:16.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e5/5ef30eb2cd81576256d7b6caaa0ce33cd1d2c2c92c8903cccb1af1a4ff2f/propcache-0.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fbe94666e62ebe36cd652f5fc012abfbc2342de99b523f8267a678e4dfdee3c", size = 47763, upload-time = "2025-03-26T03:05:18.607Z" },
-    { url = "https://files.pythonhosted.org/packages/87/9a/87091ceb048efeba4d28e903c0b15bcc84b7c0bf27dc0261e62335d9b7b8/propcache-0.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f011f104db880f4e2166bcdcf7f58250f7a465bc6b068dc84c824a3d4a5c94dc", size = 47175, upload-time = "2025-03-26T03:05:19.85Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2f/854e653c96ad1161f96194c6678a41bbb38c7947d17768e8811a77635a08/propcache-0.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e584b6d388aeb0001d6d5c2bd86b26304adde6d9bb9bfa9c4889805021b96de", size = 292265, upload-time = "2025-03-26T03:05:21.654Z" },
-    { url = "https://files.pythonhosted.org/packages/40/8d/090955e13ed06bc3496ba4a9fb26c62e209ac41973cb0d6222de20c6868f/propcache-0.3.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a17583515a04358b034e241f952f1715243482fc2c2945fd99a1b03a0bd77d6", size = 294412, upload-time = "2025-03-26T03:05:23.147Z" },
-    { url = "https://files.pythonhosted.org/packages/39/e6/d51601342e53cc7582449e6a3c14a0479fab2f0750c1f4d22302e34219c6/propcache-0.3.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5aed8d8308215089c0734a2af4f2e95eeb360660184ad3912686c181e500b2e7", size = 294290, upload-time = "2025-03-26T03:05:24.577Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/4d/be5f1a90abc1881884aa5878989a1acdafd379a91d9c7e5e12cef37ec0d7/propcache-0.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d8e309ff9a0503ef70dc9a0ebd3e69cf7b3894c9ae2ae81fc10943c37762458", size = 282926, upload-time = "2025-03-26T03:05:26.459Z" },
-    { url = "https://files.pythonhosted.org/packages/57/2b/8f61b998c7ea93a2b7eca79e53f3e903db1787fca9373af9e2cf8dc22f9d/propcache-0.3.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b655032b202028a582d27aeedc2e813299f82cb232f969f87a4fde491a233f11", size = 267808, upload-time = "2025-03-26T03:05:28.188Z" },
-    { url = "https://files.pythonhosted.org/packages/11/1c/311326c3dfce59c58a6098388ba984b0e5fb0381ef2279ec458ef99bd547/propcache-0.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f64d91b751df77931336b5ff7bafbe8845c5770b06630e27acd5dbb71e1931c", size = 290916, upload-time = "2025-03-26T03:05:29.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/74/91939924b0385e54dc48eb2e4edd1e4903ffd053cf1916ebc5347ac227f7/propcache-0.3.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:19a06db789a4bd896ee91ebc50d059e23b3639c25d58eb35be3ca1cbe967c3bf", size = 262661, upload-time = "2025-03-26T03:05:31.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/d7/e6079af45136ad325c5337f5dd9ef97ab5dc349e0ff362fe5c5db95e2454/propcache-0.3.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:bef100c88d8692864651b5f98e871fb090bd65c8a41a1cb0ff2322db39c96c27", size = 264384, upload-time = "2025-03-26T03:05:32.984Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d5/ba91702207ac61ae6f1c2da81c5d0d6bf6ce89e08a2b4d44e411c0bbe867/propcache-0.3.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:87380fb1f3089d2a0b8b00f006ed12bd41bd858fabfa7330c954c70f50ed8757", size = 291420, upload-time = "2025-03-26T03:05:34.496Z" },
-    { url = "https://files.pythonhosted.org/packages/58/70/2117780ed7edcd7ba6b8134cb7802aada90b894a9810ec56b7bb6018bee7/propcache-0.3.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e474fc718e73ba5ec5180358aa07f6aded0ff5f2abe700e3115c37d75c947e18", size = 290880, upload-time = "2025-03-26T03:05:36.256Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1f/ecd9ce27710021ae623631c0146719280a929d895a095f6d85efb6a0be2e/propcache-0.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:17d1c688a443355234f3c031349da69444be052613483f3e4158eef751abcd8a", size = 287407, upload-time = "2025-03-26T03:05:37.799Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/66/2e90547d6b60180fb29e23dc87bd8c116517d4255240ec6d3f7dc23d1926/propcache-0.3.1-cp313-cp313t-win32.whl", hash = "sha256:359e81a949a7619802eb601d66d37072b79b79c2505e6d3fd8b945538411400d", size = 42573, upload-time = "2025-03-26T03:05:39.193Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/8f/50ad8599399d1861b4d2b6b45271f0ef6af1b09b0a2386a46dbaf19c9535/propcache-0.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e7fb9a84c9abbf2b2683fa3e7b0d7da4d8ecf139a1c635732a8bda29c5214b0e", size = 46757, upload-time = "2025-03-26T03:05:40.811Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d3/c3cb8f1d6ae3b37f83e1de806713a9b3642c5895f0215a62e1a4bd6e5e34/propcache-0.3.1-py3-none-any.whl", hash = "sha256:9a8ecf38de50a7f518c21568c80f985e776397b902f1ce0b01f799aba1608b40", size = 12376, upload-time = "2025-03-26T03:06:10.5Z" },
 ]
 
 [[package]]
@@ -523,15 +294,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234, upload-time = "2025-04-18T16:44:48.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356, upload-time = "2025-04-18T16:44:46.617Z" },
-]
-
-[[package]]
-name = "pydub"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
 ]
 
 [[package]]
@@ -650,11 +412,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -700,52 +462,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
-name = "yarl"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/51/c0edba5219027f6eab262e139f73e2417b0f4efffa23bf562f6e18f76ca5/yarl-1.20.0.tar.gz", hash = "sha256:686d51e51ee5dfe62dec86e4866ee0e9ed66df700d55c828a615640adc885307", size = 185258, upload-time = "2025-04-17T00:45:14.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/6f/514c9bff2900c22a4f10e06297714dbaf98707143b37ff0bcba65a956221/yarl-1.20.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2137810a20b933b1b1b7e5cf06a64c3ed3b4747b0e5d79c9447c00db0e2f752f", size = 145030, upload-time = "2025-04-17T00:43:15.083Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/9d/f88da3fa319b8c9c813389bfb3463e8d777c62654c7168e580a13fadff05/yarl-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:447c5eadd750db8389804030d15f43d30435ed47af1313303ed82a62388176d3", size = 96894, upload-time = "2025-04-17T00:43:17.372Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/57/92e83538580a6968b2451d6c89c5579938a7309d4785748e8ad42ddafdce/yarl-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42fbe577272c203528d402eec8bf4b2d14fd49ecfec92272334270b850e9cd7d", size = 94457, upload-time = "2025-04-17T00:43:19.431Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ee/7ee43bd4cf82dddd5da97fcaddb6fa541ab81f3ed564c42f146c83ae17ce/yarl-1.20.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18e321617de4ab170226cd15006a565d0fa0d908f11f724a2c9142d6b2812ab0", size = 343070, upload-time = "2025-04-17T00:43:21.426Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/12/b5eccd1109e2097bcc494ba7dc5de156e41cf8309fab437ebb7c2b296ce3/yarl-1.20.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4345f58719825bba29895011e8e3b545e6e00257abb984f9f27fe923afca2501", size = 337739, upload-time = "2025-04-17T00:43:23.634Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/6b/0eade8e49af9fc2585552f63c76fa59ef469c724cc05b29519b19aa3a6d5/yarl-1.20.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d9b980d7234614bc4674468ab173ed77d678349c860c3af83b1fffb6a837ddc", size = 351338, upload-time = "2025-04-17T00:43:25.695Z" },
-    { url = "https://files.pythonhosted.org/packages/45/cb/aaaa75d30087b5183c7b8a07b4fb16ae0682dd149a1719b3a28f54061754/yarl-1.20.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af4baa8a445977831cbaa91a9a84cc09debb10bc8391f128da2f7bd070fc351d", size = 353636, upload-time = "2025-04-17T00:43:27.876Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9d/d9cb39ec68a91ba6e66fa86d97003f58570327d6713833edf7ad6ce9dde5/yarl-1.20.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:123393db7420e71d6ce40d24885a9e65eb1edefc7a5228db2d62bcab3386a5c0", size = 348061, upload-time = "2025-04-17T00:43:29.788Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6b/103940aae893d0cc770b4c36ce80e2ed86fcb863d48ea80a752b8bda9303/yarl-1.20.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab47acc9332f3de1b39e9b702d9c916af7f02656b2a86a474d9db4e53ef8fd7a", size = 334150, upload-time = "2025-04-17T00:43:31.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/986bd82aa222c3e6b211a69c9081ba46484cffa9fab2a5235e8d18ca7a27/yarl-1.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4a34c52ed158f89876cba9c600b2c964dfc1ca52ba7b3ab6deb722d1d8be6df2", size = 362207, upload-time = "2025-04-17T00:43:34.099Z" },
-    { url = "https://files.pythonhosted.org/packages/14/7c/63f5922437b873795d9422cbe7eb2509d4b540c37ae5548a4bb68fd2c546/yarl-1.20.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:04d8cfb12714158abf2618f792c77bc5c3d8c5f37353e79509608be4f18705c9", size = 361277, upload-time = "2025-04-17T00:43:36.202Z" },
-    { url = "https://files.pythonhosted.org/packages/81/83/450938cccf732466953406570bdb42c62b5ffb0ac7ac75a1f267773ab5c8/yarl-1.20.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7dc63ad0d541c38b6ae2255aaa794434293964677d5c1ec5d0116b0e308031f5", size = 364990, upload-time = "2025-04-17T00:43:38.551Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/de/af47d3a47e4a833693b9ec8e87debb20f09d9fdc9139b207b09a3e6cbd5a/yarl-1.20.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f9d02b591a64e4e6ca18c5e3d925f11b559c763b950184a64cf47d74d7e41877", size = 374684, upload-time = "2025-04-17T00:43:40.481Z" },
-    { url = "https://files.pythonhosted.org/packages/62/0b/078bcc2d539f1faffdc7d32cb29a2d7caa65f1a6f7e40795d8485db21851/yarl-1.20.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:95fc9876f917cac7f757df80a5dda9de59d423568460fe75d128c813b9af558e", size = 382599, upload-time = "2025-04-17T00:43:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/74/a9/4fdb1a7899f1fb47fd1371e7ba9e94bff73439ce87099d5dd26d285fffe0/yarl-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bb769ae5760cd1c6a712135ee7915f9d43f11d9ef769cb3f75a23e398a92d384", size = 378573, upload-time = "2025-04-17T00:43:44.797Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/be/29f5156b7a319e4d2e5b51ce622b4dfb3aa8d8204cd2a8a339340fbfad40/yarl-1.20.0-cp313-cp313-win32.whl", hash = "sha256:70e0c580a0292c7414a1cead1e076c9786f685c1fc4757573d2967689b370e62", size = 86051, upload-time = "2025-04-17T00:43:47.076Z" },
-    { url = "https://files.pythonhosted.org/packages/52/56/05fa52c32c301da77ec0b5f63d2d9605946fe29defacb2a7ebd473c23b81/yarl-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:4c43030e4b0af775a85be1fa0433119b1565673266a70bf87ef68a9d5ba3174c", size = 92742, upload-time = "2025-04-17T00:43:49.193Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/2f/422546794196519152fc2e2f475f0e1d4d094a11995c81a465faf5673ffd/yarl-1.20.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b6c4c3d0d6a0ae9b281e492b1465c72de433b782e6b5001c8e7249e085b69051", size = 163575, upload-time = "2025-04-17T00:43:51.533Z" },
-    { url = "https://files.pythonhosted.org/packages/90/fc/67c64ddab6c0b4a169d03c637fb2d2a212b536e1989dec8e7e2c92211b7f/yarl-1.20.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8681700f4e4df891eafa4f69a439a6e7d480d64e52bf460918f58e443bd3da7d", size = 106121, upload-time = "2025-04-17T00:43:53.506Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/00/29366b9eba7b6f6baed7d749f12add209b987c4cfbfa418404dbadc0f97c/yarl-1.20.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:84aeb556cb06c00652dbf87c17838eb6d92cfd317799a8092cee0e570ee11229", size = 103815, upload-time = "2025-04-17T00:43:55.41Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f4/a2a4c967c8323c03689383dff73396281ced3b35d0ed140580825c826af7/yarl-1.20.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f166eafa78810ddb383e930d62e623d288fb04ec566d1b4790099ae0f31485f1", size = 408231, upload-time = "2025-04-17T00:43:57.825Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a1/66f7ffc0915877d726b70cc7a896ac30b6ac5d1d2760613603b022173635/yarl-1.20.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5d3d6d14754aefc7a458261027a562f024d4f6b8a798adb472277f675857b1eb", size = 390221, upload-time = "2025-04-17T00:44:00.526Z" },
-    { url = "https://files.pythonhosted.org/packages/41/15/cc248f0504610283271615e85bf38bc014224122498c2016d13a3a1b8426/yarl-1.20.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a8f64df8ed5d04c51260dbae3cc82e5649834eebea9eadfd829837b8093eb00", size = 411400, upload-time = "2025-04-17T00:44:02.853Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/af/f0823d7e092bfb97d24fce6c7269d67fcd1aefade97d0a8189c4452e4d5e/yarl-1.20.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d9949eaf05b4d30e93e4034a7790634bbb41b8be2d07edd26754f2e38e491de", size = 411714, upload-time = "2025-04-17T00:44:04.904Z" },
-    { url = "https://files.pythonhosted.org/packages/83/70/be418329eae64b9f1b20ecdaac75d53aef098797d4c2299d82ae6f8e4663/yarl-1.20.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c366b254082d21cc4f08f522ac201d0d83a8b8447ab562732931d31d80eb2a5", size = 404279, upload-time = "2025-04-17T00:44:07.721Z" },
-    { url = "https://files.pythonhosted.org/packages/19/f5/52e02f0075f65b4914eb890eea1ba97e6fd91dd821cc33a623aa707b2f67/yarl-1.20.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91bc450c80a2e9685b10e34e41aef3d44ddf99b3a498717938926d05ca493f6a", size = 384044, upload-time = "2025-04-17T00:44:09.708Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/36/b0fa25226b03d3f769c68d46170b3e92b00ab3853d73127273ba22474697/yarl-1.20.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9c2aa4387de4bc3a5fe158080757748d16567119bef215bec643716b4fbf53f9", size = 416236, upload-time = "2025-04-17T00:44:11.734Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3a/54c828dd35f6831dfdd5a79e6c6b4302ae2c5feca24232a83cb75132b205/yarl-1.20.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d2cbca6760a541189cf87ee54ff891e1d9ea6406079c66341008f7ef6ab61145", size = 402034, upload-time = "2025-04-17T00:44:13.975Z" },
-    { url = "https://files.pythonhosted.org/packages/10/97/c7bf5fba488f7e049f9ad69c1b8fdfe3daa2e8916b3d321aa049e361a55a/yarl-1.20.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:798a5074e656f06b9fad1a162be5a32da45237ce19d07884d0b67a0aa9d5fdda", size = 407943, upload-time = "2025-04-17T00:44:16.052Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a4/022d2555c1e8fcff08ad7f0f43e4df3aba34f135bff04dd35d5526ce54ab/yarl-1.20.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f106e75c454288472dbe615accef8248c686958c2e7dd3b8d8ee2669770d020f", size = 423058, upload-time = "2025-04-17T00:44:18.547Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f6/0873a05563e5df29ccf35345a6ae0ac9e66588b41fdb7043a65848f03139/yarl-1.20.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3b60a86551669c23dc5445010534d2c5d8a4e012163218fc9114e857c0586fdd", size = 423792, upload-time = "2025-04-17T00:44:20.639Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/35/43fbbd082708fa42e923f314c24f8277a28483d219e049552e5007a9aaca/yarl-1.20.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e429857e341d5e8e15806118e0294f8073ba9c4580637e59ab7b238afca836f", size = 422242, upload-time = "2025-04-17T00:44:22.851Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f7/f0f2500cf0c469beb2050b522c7815c575811627e6d3eb9ec7550ddd0bfe/yarl-1.20.0-cp313-cp313t-win32.whl", hash = "sha256:65a4053580fe88a63e8e4056b427224cd01edfb5f951498bfefca4052f0ce0ac", size = 93816, upload-time = "2025-04-17T00:44:25.491Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/93/f73b61353b2a699d489e782c3f5998b59f974ec3156a2050a52dfd7e8946/yarl-1.20.0-cp313-cp313t-win_amd64.whl", hash = "sha256:53b2da3a6ca0a541c1ae799c349788d480e5144cac47dba0266c7cb6c76151fe", size = 101093, upload-time = "2025-04-17T00:44:27.418Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/1f/70c57b3d7278e94ed22d85e09685d3f0a38ebdd8c5c73b65ba4c0d0fe002/yarl-1.20.0-py3-none-any.whl", hash = "sha256:5d0fe6af927a47a230f31e6004621fd0959eaa915fc62acfafa67ff7229a3124", size = 46124, upload-time = "2025-04-17T00:45:12.199Z" },
 ]


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1278/upgrade-cartesia-mcp-to-cartesia-python-v3

## Summary

cartesia-mcp was pinned to Fern `cartesia` v2 since May 2026 (`pyproject.toml`: *"pin until migrated"*). cartesia-python v3 adds `default_headers`, so REST and STT WebSocket attribution work without websockets monkeypatching (#40).

Attribution uses one canonical token: `cartesia-mcp/<version>` on both `User-Agent` and `X-Cartesia-Client`.

## Changes

- Bump dependency to `cartesia[websockets]>=3.2.0,<4` (latest PyPI: **3.2.0**)
- Replace Fern v2 imports/API usage with Stainless v3
- Configure MCP headers via `Cartesia(default_headers=...)`
- STT stream: `auto_finalize` (English default) or `manual_finalize` (non-English / word timestamps)
- Pass clone `mode` and TTS `duration` via `extra_body`; pass `is_starred` via `extra_query`
- Expand `sdk_kwargs_from_request_options` for Fern v2 → v3 compat
- Fix smoke script for v3 (`admin_client`)

## Bugbot follow-ups (addressed)

| Finding | Status |
|---|---|
| Clone `mode` ignored | Fixed — `extra_body` |
| TTS `duration` dropped | Fixed — `extra_body` |
| Stream STT word timestamps | Fixed — `manual_finalize` path |
| Stream STT non-English | Fixed — route non-`en` to `manual_finalize` |
| `request_options` incomplete | Fixed — forward `extra_json`, body params, idempotency key; docs updated (`chunk_size` N/A for buffered `.read()`) |

## Test plan

- [x] `uv run pytest tests/ -q` (34 passed)
- [x] `uv run python scripts/test_all_tools.py` (all tools passed against live API)
- [ ] After merge, close #40 in favor of this approach

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large SDK migration touching all MCP tools and STT websocket behavior; regressions could affect live API calls despite expanded tests.
> 
> **Overview**
> **Migrates cartesia-mcp from Fern `cartesia` v2 to Stainless `cartesia[websockets]` v3**, replacing wrapper/`HttpClient` usage with `Cartesia` clients and v3 method names (`tts.generate`, `voice_changer.generate`, `SyncCursorIDPage` pagination).
> 
> **Client setup and attribution** now use `Cartesia(default_headers=…)` for `cartesia-version`, `User-Agent`, and `X-Cartesia-Client` (`cartesia-mcp/<version>`). Admin-only usage credits call `client.get("/usage/credits")` instead of raw httpx.
> 
> **New `request_options` adapter** maps legacy Fern-style tool `request_options` into v3 kwargs (`timeout`, `extra_headers`, `extra_query`, `extra_body`, idempotency). TTS **`duration`**, clone **`mode`**, and **`list_voices` `is_starred`** are passed via `extra_body` / `extra_query` where v3 lacks first-class params.
> 
> **STT streaming** is split: default English uses `stt.auto_finalize.websocket`; non-English or word timestamps use `manual_finalize` with finalize/close and word timestamp flattening. Pronunciation dictionary tools move from `extra_api` HTTP helpers to **`client.pronunciation_dicts`**.
> 
> Tests and the smoke script are updated for v3 (`admin_client`, websocket paths, regression coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237b4574c7447d432b30a65c14f972ef6bdce54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->