### PR TITLE
feat: hosted Streamable HTTP MCP with OAuth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,24 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest
+
+  docker-build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: docker build -t cartesia-mcp:ci .
+
+      - name: Smoke test /health
+        run: |
+          docker run -d --name mcp-ci -p 8000:8000 cartesia-mcp:ci
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs mcp-ci
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV MCP_HOSTED=1
+ENV PORT=8000
+
+COPY pyproject.toml README.md ./
+COPY cartesia_mcp ./cartesia_mcp
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["cartesia-mcp", "--transport", "streamable-http"]

--- a/cartesia_mcp/clients.py
+++ b/cartesia_mcp/clients.py
@@ -1,0 +1,45 @@
+"""Request-scoped Cartesia SDK clients."""
+
+from __future__ import annotations
+
+from cartesia import Cartesia
+
+from cartesia_mcp.config import ADMIN_HTTP_REQUIRED_MESSAGE, ensure_admin_client
+from cartesia_mcp.credentials import resolve_admin_api_credential, resolve_api_credential
+from cartesia_mcp.sdk_setup import create_cartesia_client
+
+
+def get_client() -> Cartesia:
+    return create_cartesia_client(resolve_api_credential())
+
+
+def get_admin_client() -> Cartesia:
+    admin_key = resolve_admin_api_credential()
+    if admin_key is None:
+        raise ValueError(ADMIN_HTTP_REQUIRED_MESSAGE)
+    return create_cartesia_client(admin_key)
+
+
+def require_admin_client() -> Cartesia:
+    admin_key = resolve_admin_api_credential()
+    return ensure_admin_client(
+        create_cartesia_client(admin_key) if admin_key else None
+    )
+
+
+class _CartesiaClientProxy:
+    def __getattr__(self, name: str):
+        if name == "__func__":
+            raise AttributeError(name)
+        return getattr(get_client(), name)
+
+
+class _AdminClientProxy:
+    def __getattr__(self, name: str):
+        if name == "__func__":
+            raise AttributeError(name)
+        return getattr(require_admin_client(), name)
+
+
+client = _CartesiaClientProxy()
+admin_client = _AdminClientProxy()

--- a/cartesia_mcp/config.py
+++ b/cartesia_mcp/config.py
@@ -28,11 +28,13 @@ def env_or_none(
 def validate_api_keys(
     api_key: str | None,
     admin_api_key: str | None,
-) -> tuple[str, str | None]:
-    if not api_key:
+    *,
+    require_api_key: bool = True,
+) -> tuple[str | None, str | None]:
+    if require_api_key and not api_key:
         raise ValueError("CARTESIA_API_KEY is required")
 
-    if is_admin_api_key(api_key):
+    if api_key is not None and is_admin_api_key(api_key):
         raise ValueError(
             "CARTESIA_API_KEY must be a standard API key (sk_car_...), not an admin key. "
             "Use CARTESIA_ADMIN_API_KEY for admin-only tools such as get_credit_usage."

--- a/cartesia_mcp/credentials.py
+++ b/cartesia_mcp/credentials.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from contextvars import ContextVar
+
 from cartesia_mcp.config import env_or_none
 from cartesia_mcp.sdk_setup import is_admin_api_key
 
 _stdio_api_key: str | None = None
 _stdio_admin_api_key: str | None = None
+_hosted_admin_credential: ContextVar[str | None] = ContextVar(
+    "hosted_admin_credential",
+    default=None,
+)
 
 
 def configure_stdio_credentials(
@@ -16,6 +22,10 @@ def configure_stdio_credentials(
     global _stdio_api_key, _stdio_admin_api_key
     _stdio_api_key = api_key
     _stdio_admin_api_key = admin_api_key
+
+
+def set_hosted_admin_credential(admin_credential: str | None) -> None:
+    _hosted_admin_credential.set(admin_credential)
 
 
 def resolve_api_credential() -> str:
@@ -38,6 +48,9 @@ def resolve_api_credential() -> str:
 
 
 def resolve_admin_api_credential() -> str | None:
+    hosted_admin = _hosted_admin_credential.get()
+    if hosted_admin:
+        return hosted_admin
     if _stdio_admin_api_key:
         return _stdio_admin_api_key
     return None

--- a/cartesia_mcp/credentials.py
+++ b/cartesia_mcp/credentials.py
@@ -1,0 +1,57 @@
+"""Resolve Cartesia API credentials for stdio vs hosted MCP."""
+
+from __future__ import annotations
+
+from cartesia_mcp.config import env_or_none
+from cartesia_mcp.sdk_setup import is_admin_api_key
+
+_stdio_api_key: str | None = None
+_stdio_admin_api_key: str | None = None
+
+
+def configure_stdio_credentials(
+    api_key: str,
+    admin_api_key: str | None,
+) -> None:
+    global _stdio_api_key, _stdio_admin_api_key
+    _stdio_api_key = api_key
+    _stdio_admin_api_key = admin_api_key
+
+
+def resolve_api_credential() -> str:
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+
+        access = get_access_token()
+        if access is not None and access.token:
+            return access.token
+    except ImportError:
+        pass
+
+    if _stdio_api_key:
+        return _stdio_api_key
+
+    raise ValueError(
+        "No Cartesia credential. Set CARTESIA_API_KEY for stdio, or authenticate "
+        "via bearer token / OAuth for hosted MCP."
+    )
+
+
+def resolve_admin_api_credential() -> str | None:
+    if _stdio_admin_api_key:
+        return _stdio_admin_api_key
+    return None
+
+
+def looks_like_cartesia_api_key(token: str) -> bool:
+    return token.startswith("sk_car_") and not token.startswith("sk_car_admin_")
+
+
+def looks_like_cartesia_access_token(token: str) -> bool:
+    return token.startswith("eyJ")
+
+
+def is_valid_bearer_credential(token: str) -> bool:
+    if looks_like_cartesia_api_key(token):
+        return not is_admin_api_key(token)
+    return looks_like_cartesia_access_token(token)

--- a/cartesia_mcp/credentials.py
+++ b/cartesia_mcp/credentials.py
@@ -9,10 +9,16 @@ from cartesia_mcp.sdk_setup import is_admin_api_key
 
 _stdio_api_key: str | None = None
 _stdio_admin_api_key: str | None = None
+_hosted_mode: bool = False
 _hosted_admin_credential: ContextVar[str | None] = ContextVar(
     "hosted_admin_credential",
     default=None,
 )
+
+
+def configure_hosted_mode(enabled: bool = True) -> None:
+    global _hosted_mode
+    _hosted_mode = enabled
 
 
 def configure_stdio_credentials(
@@ -51,6 +57,8 @@ def resolve_admin_api_credential() -> str | None:
     hosted_admin = _hosted_admin_credential.get()
     if hosted_admin:
         return hosted_admin
+    if _hosted_mode:
+        return None
     if _stdio_admin_api_key:
         return _stdio_admin_api_key
     return None

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -79,9 +79,18 @@ async def oauth_internal_complete(request: Request) -> Response:
 
     body = await request.json()
     session_id = body.get("session_id")
+    connect_token = body.get("connect_token")
     cartesia_credential = body.get("cartesia_credential")
+    completing_owner_id = body.get("completing_owner_id")
+    completing_user_id = body.get("completing_user_id")
     cartesia_admin_credential = body.get("cartesia_admin_credential")
-    if not session_id or not cartesia_credential:
+    if (
+        not session_id
+        or not connect_token
+        or not cartesia_credential
+        or not completing_owner_id
+        or not completing_user_id
+    ):
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     from cartesia_mcp.oauth_store import oauth_store
@@ -89,11 +98,16 @@ async def oauth_internal_complete(request: Request) -> Response:
     try:
         pending = oauth_store.attach_credential(
             session_id,
+            connect_token,
             cartesia_credential,
+            completing_owner_id=completing_owner_id,
+            completing_user_id=completing_user_id,
             cartesia_admin_credential=cartesia_admin_credential,
         )
     except KeyError:
         return JSONResponse({"error": "unknown_session"}, status_code=404)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
 
     provider = CartesiaOAuthProvider(
         playground_url=playground_public_url(),

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import hmac
-import os
 from typing import Any
 
 from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
 from mcp.server.fastmcp import FastMCP
 from pydantic import AnyHttpUrl
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from cartesia_mcp.config import env_or_none
@@ -114,31 +113,11 @@ async def oauth_internal_complete(request: Request) -> Response:
         mcp_server_url=server_public_url(),
     )
     redirect_url = provider.build_resume_redirect(session_id, pending)
-    oauth_store.pop_pending(session_id)
-    return JSONResponse({"redirect_url": redirect_url})
-
-
-async def oauth_browser_resume(request: Request) -> Response:
-    session_id = request.query_params.get("session")
-    if not session_id:
-        return JSONResponse({"error": "missing session"}, status_code=400)
-
-    from cartesia_mcp.oauth_store import oauth_store
-
     try:
-        pending = oauth_store.pop_pending(session_id)
+        oauth_store.pop_pending(session_id)
     except KeyError:
-        return JSONResponse({"error": "unknown_session"}, status_code=404)
-
-    if not pending.cartesia_credential:
-        return JSONResponse({"error": "session_not_ready"}, status_code=400)
-
-    provider = CartesiaOAuthProvider(
-        playground_url=playground_public_url(),
-        mcp_server_url=server_public_url(),
-    )
-    redirect_url = provider.build_resume_redirect(session_id, pending)
-    return RedirectResponse(redirect_url, status_code=302)
+        pass
+    return JSONResponse({"redirect_url": redirect_url})
 
 
 def attach_hosted_routes(mcp: FastMCP) -> None:
@@ -149,11 +128,6 @@ def attach_hosted_routes(mcp: FastMCP) -> None:
                 "/internal/oauth/complete",
                 endpoint=oauth_internal_complete,
                 methods=["POST"],
-            ),
-            Route(
-                "/oauth/resume",
-                endpoint=oauth_browser_resume,
-                methods=["GET"],
             ),
         ]
     )

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -1,0 +1,145 @@
+"""Hosted Streamable HTTP MCP server configuration and routes."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Any
+
+from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
+from mcp.server.fastmcp import FastMCP
+from pydantic import AnyHttpUrl
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from cartesia_mcp.config import env_or_none
+from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+
+
+def hosted_enabled() -> bool:
+    return bool(env_or_none("MCP_HOSTED"))
+
+
+def server_public_url() -> str:
+    return (env_or_none("MCP_SERVER_URL") or "http://127.0.0.1:8000").rstrip("/")
+
+
+def playground_public_url() -> str:
+    return (env_or_none("PLAYGROUND_URL") or "https://play.cartesia.ai").rstrip("/")
+
+
+def internal_secret() -> str | None:
+    return env_or_none("MCP_INTERNAL_SECRET")
+
+
+def fastmcp_hosted_kwargs() -> dict[str, Any]:
+    mcp_url = server_public_url()
+    provider = CartesiaOAuthProvider(
+        playground_url=playground_public_url(),
+        mcp_server_url=mcp_url,
+    )
+    return {
+        "host": "0.0.0.0",
+        "port": int(env_or_none("PORT") or "8000"),
+        "streamable_http_path": "/mcp",
+        "stateless_http": True,
+        "auth_server_provider": provider,
+        "auth": AuthSettings(
+            issuer_url=AnyHttpUrl(mcp_url),
+            resource_server_url=AnyHttpUrl(mcp_url),
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=["mcp"],
+                default_scopes=["mcp"],
+            ),
+            required_scopes=["mcp"],
+        ),
+    }
+
+
+def _authorized_internal(request: Request) -> bool:
+    secret = internal_secret()
+    if not secret:
+        return False
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return False
+    token = auth[7:]
+    return hmac.compare_digest(token, secret)
+
+
+async def health(_: Request) -> Response:
+    return JSONResponse({"status": "ok"})
+
+
+async def oauth_internal_complete(request: Request) -> Response:
+    if not _authorized_internal(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    body = await request.json()
+    session_id = body.get("session_id")
+    cartesia_credential = body.get("cartesia_credential")
+    if not session_id or not cartesia_credential:
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    from cartesia_mcp.oauth_store import oauth_store
+
+    try:
+        pending = oauth_store.attach_credential(session_id, cartesia_credential)
+    except KeyError:
+        return JSONResponse({"error": "unknown_session"}, status_code=404)
+
+    provider = CartesiaOAuthProvider(
+        playground_url=playground_public_url(),
+        mcp_server_url=server_public_url(),
+    )
+    redirect_url = provider.build_resume_redirect(session_id, pending)
+    oauth_store.pop_pending(session_id)
+    return JSONResponse({"redirect_url": redirect_url})
+
+
+async def oauth_browser_resume(request: Request) -> Response:
+    session_id = request.query_params.get("session")
+    if not session_id:
+        return JSONResponse({"error": "missing session"}, status_code=400)
+
+    from cartesia_mcp.oauth_store import oauth_store
+
+    try:
+        pending = oauth_store.pop_pending(session_id)
+    except KeyError:
+        return JSONResponse({"error": "unknown_session"}, status_code=404)
+
+    if not pending.cartesia_credential:
+        return JSONResponse({"error": "session_not_ready"}, status_code=400)
+
+    provider = CartesiaOAuthProvider(
+        playground_url=playground_public_url(),
+        mcp_server_url=server_public_url(),
+    )
+    redirect_url = provider.build_resume_redirect(session_id, pending)
+    return RedirectResponse(redirect_url, status_code=302)
+
+
+def attach_hosted_routes(mcp: FastMCP) -> None:
+    mcp._custom_starlette_routes.extend(
+        [
+            Route("/health", endpoint=health, methods=["GET"]),
+            Route(
+                "/internal/oauth/complete",
+                endpoint=oauth_internal_complete,
+                methods=["POST"],
+            ),
+            Route(
+                "/oauth/resume",
+                endpoint=oauth_browser_resume,
+                methods=["GET"],
+            ),
+        ]
+    )
+
+
+def run_hosted(mcp: FastMCP) -> None:
+    attach_hosted_routes(mcp)
+    mcp.run(transport="streamable-http")

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -97,14 +97,20 @@ async def oauth_internal_complete(request: Request) -> Response:
 
     from cartesia_mcp.oauth_store import oauth_store
 
-    cached_redirect = oauth_store.get_completed_redirect(
+    provider = CartesiaOAuthProvider(
+        playground_url=playground_public_url(),
+        mcp_server_url=server_public_url(),
+    )
+
+    completed = oauth_store.get_completed_session(
         session_id,
         connect_token,
         completing_owner_id,
         completing_user_id,
     )
-    if cached_redirect:
-        return JSONResponse({"redirect_url": cached_redirect})
+    if completed is not None:
+        redirect_url = provider.build_resume_redirect(session_id, completed)
+        return JSONResponse({"redirect_url": redirect_url})
 
     try:
         pending = oauth_store.attach_credential(
@@ -120,17 +126,13 @@ async def oauth_internal_complete(request: Request) -> Response:
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
 
-    provider = CartesiaOAuthProvider(
-        playground_url=playground_public_url(),
-        mcp_server_url=server_public_url(),
-    )
     redirect_url = provider.build_resume_redirect(session_id, pending)
-    oauth_store.remember_completed_redirect(
+    oauth_store.remember_completed_session(
         session_id,
         connect_token,
         completing_owner_id,
         completing_user_id,
-        redirect_url,
+        pending,
     )
     try:
         oauth_store.pop_pending(session_id)

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -17,7 +17,10 @@ from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
 
 
 def hosted_enabled() -> bool:
-    return bool(env_or_none("MCP_HOSTED"))
+    value = env_or_none("MCP_HOSTED")
+    if value is None:
+        return False
+    return value.lower() in ("1", "true", "yes", "on")
 
 
 def server_public_url() -> str:
@@ -94,6 +97,15 @@ async def oauth_internal_complete(request: Request) -> Response:
 
     from cartesia_mcp.oauth_store import oauth_store
 
+    cached_redirect = oauth_store.get_completed_redirect(
+        session_id,
+        connect_token,
+        completing_owner_id,
+        completing_user_id,
+    )
+    if cached_redirect:
+        return JSONResponse({"redirect_url": cached_redirect})
+
     try:
         pending = oauth_store.attach_credential(
             session_id,
@@ -113,6 +125,13 @@ async def oauth_internal_complete(request: Request) -> Response:
         mcp_server_url=server_public_url(),
     )
     redirect_url = provider.build_resume_redirect(session_id, pending)
+    oauth_store.remember_completed_redirect(
+        session_id,
+        connect_token,
+        completing_owner_id,
+        completing_user_id,
+        redirect_url,
+    )
     try:
         oauth_store.pop_pending(session_id)
     except KeyError:

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -80,13 +80,18 @@ async def oauth_internal_complete(request: Request) -> Response:
     body = await request.json()
     session_id = body.get("session_id")
     cartesia_credential = body.get("cartesia_credential")
+    cartesia_admin_credential = body.get("cartesia_admin_credential")
     if not session_id or not cartesia_credential:
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     from cartesia_mcp.oauth_store import oauth_store
 
     try:
-        pending = oauth_store.attach_credential(session_id, cartesia_credential)
+        pending = oauth_store.attach_credential(
+            session_id,
+            cartesia_credential,
+            cartesia_admin_credential=cartesia_admin_credential,
+        )
     except KeyError:
         return JSONResponse({"error": "unknown_session"}, status_code=404)
 

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -1,0 +1,157 @@
+"""MCP OAuth authorization server backed by Clerk login on the playground."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+from urllib.parse import urlencode
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RegistrationError,
+    TokenError,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+
+from cartesia_mcp.oauth_store import oauth_store
+
+
+class CartesiaOAuthProvider(
+    OAuthAuthorizationServerProvider[AuthorizationCode, Any, AuthorizationCode]
+):
+    def __init__(self, *, playground_url: str, mcp_server_url: str) -> None:
+        self._playground_url = playground_url.rstrip("/")
+        self._mcp_server_url = mcp_server_url.rstrip("/")
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return oauth_store.get_client(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if not client_info.redirect_uris:
+            raise RegistrationError(
+                error="invalid_client_metadata",
+                error_description="redirect_uris is required",
+            )
+        oauth_store.register_client(client_info)
+
+    async def authorize(
+        self,
+        client: OAuthClientInformationFull,
+        params: AuthorizationParams,
+    ) -> str:
+        session_id = oauth_store.create_pending_session(client.client_id, params)
+        query = urlencode({"session": session_id})
+        return f"{self._playground_url}/mcp/connect?{query}"
+
+    async def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> AuthorizationCode | None:
+        return oauth_store.load_authorization_code(client, authorization_code)
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        try:
+            return oauth_store.exchange_authorization_code(client, authorization_code)
+        except ValueError as exc:
+            raise TokenError(error="invalid_grant", error_description=str(exc)) from exc
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> None:
+        return None
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: Any,
+        scopes: list[str],
+    ) -> OAuthToken:
+        raise TokenError(
+            error="unsupported_grant_type",
+            error_description="Refresh tokens are not supported",
+        )
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        from cartesia_mcp.credentials import is_valid_bearer_credential
+
+        if is_valid_bearer_credential(token):
+            return AccessToken(
+                token=token,
+                client_id="cartesia_credential",
+                scopes=["mcp"],
+                expires_at=None,
+            )
+
+        stored = oauth_store.resolve_mcp_access_token(token)
+        if stored is None:
+            return None
+
+        return AccessToken(
+            token=stored.cartesia_credential,
+            client_id=stored.client_id,
+            scopes=stored.scopes or ["mcp"],
+            expires_at=stored.expires_at,
+        )
+
+    async def revoke_token(
+        self,
+        token: Any,
+    ) -> None:
+        if isinstance(token, str):
+            oauth_store._mcp_tokens.pop(token, None)
+
+    def build_resume_redirect(self, session_id: str, pending) -> str:
+        auth_code = oauth_store.issue_authorization_code(
+            client_id=pending.client_id,
+            params=pending.params,
+            cartesia_credential=pending.cartesia_credential or "",
+        )
+        query = urlencode(
+            {
+                "code": auth_code.code,
+                "state": pending.params.state or "",
+            }
+        )
+        redirect_base = str(pending.params.redirect_uri)
+        separator = "&" if "?" in redirect_base else "?"
+        return f"{redirect_base}{separator}{query}"
+
+
+def ensure_dynamic_client(client_id: str, redirect_uri: AnyUrl) -> OAuthClientInformationFull:
+    existing = oauth_store.get_client(client_id)
+    if existing is not None:
+        return existing
+    client = OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret=None,
+        redirect_uris=[redirect_uri],
+        client_name="MCP Client",
+        token_endpoint_auth_method="none",
+    )
+    oauth_store.register_client(client)
+    return client
+
+
+def register_ephemeral_client(redirect_uri: str | None = None) -> OAuthClientInformationFull:
+    client_id = secrets.token_urlsafe(16)
+    redirect_uris = [AnyUrl(redirect_uri)] if redirect_uri else [AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback")]
+    client = OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret=None,
+        redirect_uris=redirect_uris,
+        client_name="MCP Client",
+        token_endpoint_auth_method="none",
+    )
+    oauth_store.register_client(client)
+    return client

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -97,6 +97,10 @@ class CartesiaOAuthProvider(
         if stored is None:
             return None
 
+        from cartesia_mcp.credentials import set_hosted_admin_credential
+
+        set_hosted_admin_credential(stored.cartesia_admin_credential)
+
         return AccessToken(
             token=stored.cartesia_credential,
             client_id=stored.client_id,
@@ -116,6 +120,7 @@ class CartesiaOAuthProvider(
             client_id=pending.client_id,
             params=pending.params,
             cartesia_credential=pending.cartesia_credential or "",
+            cartesia_admin_credential=pending.cartesia_admin_credential,
         )
         query = urlencode(
             {

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -98,6 +98,19 @@ class CartesiaOAuthProvider(
         )
 
     async def load_access_token(self, token: str) -> AccessToken | None:
+        stored = oauth_store.resolve_mcp_access_token(token)
+        if stored is not None:
+            from cartesia_mcp.credentials import set_hosted_admin_credential
+
+            set_hosted_admin_credential(stored.cartesia_admin_credential)
+
+            return AccessToken(
+                token=stored.cartesia_credential,
+                client_id=stored.client_id,
+                scopes=stored.scopes or ["mcp"],
+                expires_at=stored.expires_at,
+            )
+
         from cartesia_mcp.credentials import is_valid_bearer_credential
 
         if is_valid_bearer_credential(token):
@@ -108,20 +121,7 @@ class CartesiaOAuthProvider(
                 expires_at=None,
             )
 
-        stored = oauth_store.resolve_mcp_access_token(token)
-        if stored is None:
-            return None
-
-        from cartesia_mcp.credentials import set_hosted_admin_credential
-
-        set_hosted_admin_credential(stored.cartesia_admin_credential)
-
-        return AccessToken(
-            token=stored.cartesia_credential,
-            client_id=stored.client_id,
-            scopes=stored.scopes or ["mcp"],
-            expires_at=stored.expires_at,
-        )
+        return None
 
     async def revoke_token(
         self,

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -19,6 +19,13 @@ from pydantic import AnyUrl
 
 from cartesia_mcp.oauth_store import oauth_store
 
+_ALLOWED_REDIRECT_SCHEMES = ("cursor:", "vscode:", "http:", "https:")
+
+
+def _redirect_uri_is_allowed(redirect_uri: AnyUrl) -> bool:
+    parsed = redirect_uri.unicode_string()
+    return parsed.startswith(_ALLOWED_REDIRECT_SCHEMES)
+
 
 class CartesiaOAuthProvider(
     OAuthAuthorizationServerProvider[AuthorizationCode, Any, AuthorizationCode]
@@ -36,6 +43,11 @@ class CartesiaOAuthProvider(
                 error="invalid_client_metadata",
                 error_description="redirect_uris is required",
             )
+        if not all(_redirect_uri_is_allowed(uri) for uri in client_info.redirect_uris):
+            raise RegistrationError(
+                error="invalid_client_metadata",
+                error_description="redirect_uris must use cursor, vscode, http, or https",
+            )
         oauth_store.register_client(client_info)
 
     async def authorize(
@@ -43,8 +55,11 @@ class CartesiaOAuthProvider(
         client: OAuthClientInformationFull,
         params: AuthorizationParams,
     ) -> str:
-        session_id = oauth_store.create_pending_session(client.client_id, params)
-        query = urlencode({"session": session_id})
+        session_id, connect_token = oauth_store.create_pending_session(
+            client.client_id,
+            params,
+        )
+        query = urlencode({"session": session_id, "token": connect_token})
         return f"{self._playground_url}/mcp/connect?{query}"
 
     async def load_authorization_code(

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -37,6 +37,7 @@ class OAuthStore:
     def __init__(self) -> None:
         self._clients: dict[str, OAuthClientInformationFull] = {}
         self._pending: dict[str, PendingConnectSession] = {}
+        self._completed_redirects: dict[str, str] = {}
         self._auth_codes: dict[str, AuthorizationCode] = {}
         self._mcp_tokens: dict[str, StoredMcpAccessToken] = {}
 
@@ -84,6 +85,13 @@ class OAuthStore:
     ) -> PendingConnectSession:
         pending = self.get_pending_session(session_id, connect_token)
         if pending.cartesia_credential is not None:
+            if (
+                pending.completing_owner_id == completing_owner_id
+                and pending.completing_user_id == completing_user_id
+                and pending.cartesia_credential == cartesia_credential
+                and pending.cartesia_admin_credential == cartesia_admin_credential
+            ):
+                return pending
             raise ValueError("MCP OAuth session already completed")
         if (
             pending.completing_owner_id is not None
@@ -95,6 +103,46 @@ class OAuthStore:
         pending.cartesia_credential = cartesia_credential
         pending.cartesia_admin_credential = cartesia_admin_credential
         return pending
+
+    def remember_completed_redirect(
+        self,
+        session_id: str,
+        connect_token: str,
+        completing_owner_id: str,
+        completing_user_id: str,
+        redirect_url: str,
+    ) -> None:
+        key = self._completed_redirect_key(
+            session_id,
+            connect_token,
+            completing_owner_id,
+            completing_user_id,
+        )
+        self._completed_redirects[key] = redirect_url
+
+    def get_completed_redirect(
+        self,
+        session_id: str,
+        connect_token: str,
+        completing_owner_id: str,
+        completing_user_id: str,
+    ) -> str | None:
+        key = self._completed_redirect_key(
+            session_id,
+            connect_token,
+            completing_owner_id,
+            completing_user_id,
+        )
+        return self._completed_redirects.get(key)
+
+    def _completed_redirect_key(
+        self,
+        session_id: str,
+        connect_token: str,
+        completing_owner_id: str,
+        completing_user_id: str,
+    ) -> str:
+        return f"{session_id}:{connect_token}:{completing_owner_id}:{completing_user_id}"
 
     def pop_pending(self, session_id: str) -> PendingConnectSession:
         pending = self._pending.pop(session_id, None)

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -37,7 +37,7 @@ class OAuthStore:
     def __init__(self) -> None:
         self._clients: dict[str, OAuthClientInformationFull] = {}
         self._pending: dict[str, PendingConnectSession] = {}
-        self._completed_redirects: dict[str, str] = {}
+        self._completed_sessions: dict[str, PendingConnectSession] = {}
         self._auth_codes: dict[str, AuthorizationCode] = {}
         self._mcp_tokens: dict[str, StoredMcpAccessToken] = {}
 
@@ -89,8 +89,9 @@ class OAuthStore:
                 pending.completing_owner_id == completing_owner_id
                 and pending.completing_user_id == completing_user_id
                 and pending.cartesia_credential == cartesia_credential
-                and pending.cartesia_admin_credential == cartesia_admin_credential
             ):
+                if cartesia_admin_credential:
+                    pending.cartesia_admin_credential = cartesia_admin_credential
                 return pending
             raise ValueError("MCP OAuth session already completed")
         if (
@@ -104,13 +105,13 @@ class OAuthStore:
         pending.cartesia_admin_credential = cartesia_admin_credential
         return pending
 
-    def remember_completed_redirect(
+    def remember_completed_session(
         self,
         session_id: str,
         connect_token: str,
         completing_owner_id: str,
         completing_user_id: str,
-        redirect_url: str,
+        pending: PendingConnectSession,
     ) -> None:
         key = self._completed_redirect_key(
             session_id,
@@ -118,22 +119,22 @@ class OAuthStore:
             completing_owner_id,
             completing_user_id,
         )
-        self._completed_redirects[key] = redirect_url
+        self._completed_sessions[key] = pending
 
-    def get_completed_redirect(
+    def get_completed_session(
         self,
         session_id: str,
         connect_token: str,
         completing_owner_id: str,
         completing_user_id: str,
-    ) -> str | None:
+    ) -> PendingConnectSession | None:
         key = self._completed_redirect_key(
             session_id,
             connect_token,
             completing_owner_id,
             completing_user_id,
         )
-        return self._completed_redirects.get(key)
+        return self._completed_sessions.get(key)
 
     def _completed_redirect_key(
         self,

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -15,8 +15,11 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 class PendingConnectSession:
     client_id: str
     params: AuthorizationParams
+    connect_token: str
     cartesia_credential: str | None = None
     cartesia_admin_credential: str | None = None
+    completing_owner_id: str | None = None
+    completing_user_id: str | None = None
     created_at: float = field(default_factory=time.time)
 
 
@@ -47,24 +50,48 @@ class OAuthStore:
         self,
         client_id: str,
         params: AuthorizationParams,
-    ) -> str:
+    ) -> tuple[str, str]:
         session_id = secrets.token_urlsafe(32)
+        connect_token = secrets.token_urlsafe(32)
         self._pending[session_id] = PendingConnectSession(
             client_id=client_id,
             params=params,
+            connect_token=connect_token,
         )
-        return session_id
+        return session_id, connect_token
+
+    def get_pending_session(
+        self,
+        session_id: str,
+        connect_token: str,
+    ) -> PendingConnectSession:
+        pending = self._pending.get(session_id)
+        if pending is None or not secrets.compare_digest(
+            pending.connect_token, connect_token
+        ):
+            raise KeyError(f"Unknown MCP OAuth session: {session_id}")
+        return pending
 
     def attach_credential(
         self,
         session_id: str,
+        connect_token: str,
         cartesia_credential: str,
         *,
+        completing_owner_id: str,
+        completing_user_id: str,
         cartesia_admin_credential: str | None = None,
     ) -> PendingConnectSession:
-        pending = self._pending.get(session_id)
-        if pending is None:
-            raise KeyError(f"Unknown MCP OAuth session: {session_id}")
+        pending = self.get_pending_session(session_id, connect_token)
+        if pending.cartesia_credential is not None:
+            raise ValueError("MCP OAuth session already completed")
+        if (
+            pending.completing_owner_id is not None
+            and pending.completing_owner_id != completing_owner_id
+        ):
+            raise ValueError("MCP OAuth session bound to a different organization")
+        pending.completing_owner_id = completing_owner_id
+        pending.completing_user_id = completing_user_id
         pending.cartesia_credential = cartesia_credential
         pending.cartesia_admin_credential = cartesia_admin_credential
         return pending

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -16,6 +16,7 @@ class PendingConnectSession:
     client_id: str
     params: AuthorizationParams
     cartesia_credential: str | None = None
+    cartesia_admin_credential: str | None = None
     created_at: float = field(default_factory=time.time)
 
 
@@ -26,6 +27,7 @@ class StoredMcpAccessToken:
     client_id: str
     scopes: list[str]
     expires_at: int
+    cartesia_admin_credential: str | None = None
 
 
 class OAuthStore:
@@ -53,11 +55,18 @@ class OAuthStore:
         )
         return session_id
 
-    def attach_credential(self, session_id: str, cartesia_credential: str) -> PendingConnectSession:
+    def attach_credential(
+        self,
+        session_id: str,
+        cartesia_credential: str,
+        *,
+        cartesia_admin_credential: str | None = None,
+    ) -> PendingConnectSession:
         pending = self._pending.get(session_id)
         if pending is None:
             raise KeyError(f"Unknown MCP OAuth session: {session_id}")
         pending.cartesia_credential = cartesia_credential
+        pending.cartesia_admin_credential = cartesia_admin_credential
         return pending
 
     def pop_pending(self, session_id: str) -> PendingConnectSession:
@@ -72,6 +81,7 @@ class OAuthStore:
         client_id: str,
         params: AuthorizationParams,
         cartesia_credential: str,
+        cartesia_admin_credential: str | None = None,
     ) -> AuthorizationCode:
         code = secrets.token_urlsafe(32)
         auth_code = AuthorizationCode(
@@ -91,6 +101,7 @@ class OAuthStore:
             client_id=client_id,
             scopes=list(params.scopes or []),
             expires_at=int(time.time()) + 600,
+            cartesia_admin_credential=cartesia_admin_credential,
         )
         return auth_code
 
@@ -124,6 +135,7 @@ class OAuthStore:
             client_id=client.client_id,
             scopes=stored.scopes,
             expires_at=expires_at,
+            cartesia_admin_credential=stored.cartesia_admin_credential,
         )
         return OAuthToken(
             access_token=access_token,

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -1,0 +1,144 @@
+"""In-memory OAuth state for hosted MCP (single-process; replace with Redis for scale)."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from mcp.server.auth.provider import AuthorizationCode, AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+
+@dataclass
+class PendingConnectSession:
+    client_id: str
+    params: AuthorizationParams
+    cartesia_credential: str | None = None
+    created_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class StoredMcpAccessToken:
+    token: str
+    cartesia_credential: str
+    client_id: str
+    scopes: list[str]
+    expires_at: int
+
+
+class OAuthStore:
+    def __init__(self) -> None:
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._pending: dict[str, PendingConnectSession] = {}
+        self._auth_codes: dict[str, AuthorizationCode] = {}
+        self._mcp_tokens: dict[str, StoredMcpAccessToken] = {}
+
+    def register_client(self, client: OAuthClientInformationFull) -> None:
+        self._clients[client.client_id] = client
+
+    def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    def create_pending_session(
+        self,
+        client_id: str,
+        params: AuthorizationParams,
+    ) -> str:
+        session_id = secrets.token_urlsafe(32)
+        self._pending[session_id] = PendingConnectSession(
+            client_id=client_id,
+            params=params,
+        )
+        return session_id
+
+    def attach_credential(self, session_id: str, cartesia_credential: str) -> PendingConnectSession:
+        pending = self._pending.get(session_id)
+        if pending is None:
+            raise KeyError(f"Unknown MCP OAuth session: {session_id}")
+        pending.cartesia_credential = cartesia_credential
+        return pending
+
+    def pop_pending(self, session_id: str) -> PendingConnectSession:
+        pending = self._pending.pop(session_id, None)
+        if pending is None:
+            raise KeyError(f"Unknown MCP OAuth session: {session_id}")
+        return pending
+
+    def issue_authorization_code(
+        self,
+        *,
+        client_id: str,
+        params: AuthorizationParams,
+        cartesia_credential: str,
+    ) -> AuthorizationCode:
+        code = secrets.token_urlsafe(32)
+        auth_code = AuthorizationCode(
+            code=code,
+            scopes=list(params.scopes or []),
+            expires_at=time.time() + 600,
+            client_id=client_id,
+            code_challenge=params.code_challenge,
+            redirect_uri=params.redirect_uri,
+            redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
+            resource=params.resource,
+        )
+        self._auth_codes[code] = auth_code
+        self._mcp_tokens[f"code:{code}"] = StoredMcpAccessToken(
+            token=f"code:{code}",
+            cartesia_credential=cartesia_credential,
+            client_id=client_id,
+            scopes=list(params.scopes or []),
+            expires_at=int(time.time()) + 600,
+        )
+        return auth_code
+
+    def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> AuthorizationCode | None:
+        stored = self._auth_codes.get(authorization_code)
+        if stored is None or stored.client_id != client.client_id:
+            return None
+        if stored.expires_at < time.time():
+            return None
+        return stored
+
+    def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        stored = self._mcp_tokens.pop(f"code:{authorization_code.code}", None)
+        self._auth_codes.pop(authorization_code.code, None)
+        if stored is None:
+            raise ValueError("Authorization code not found")
+
+        access_token = secrets.token_urlsafe(32)
+        expires_at = int(time.time()) + 3600
+        self._mcp_tokens[access_token] = StoredMcpAccessToken(
+            token=access_token,
+            cartesia_credential=stored.cartesia_credential,
+            client_id=client.client_id,
+            scopes=stored.scopes,
+            expires_at=expires_at,
+        )
+        return OAuthToken(
+            access_token=access_token,
+            token_type="Bearer",
+            expires_in=3600,
+            scope=" ".join(stored.scopes) if stored.scopes else None,
+        )
+
+    def resolve_mcp_access_token(self, token: str) -> StoredMcpAccessToken | None:
+        stored = self._mcp_tokens.get(token)
+        if stored is None:
+            return None
+        if stored.expires_at < int(time.time()):
+            return None
+        return stored
+
+
+oauth_store = OAuthStore()

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -2,7 +2,9 @@
 Cartesia MCP Server
 """
 
+import argparse
 import os
+import sys
 import typing
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
@@ -35,8 +37,10 @@ from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
 from cartesia_mcp.extra_api import UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
+from cartesia_mcp.clients import admin_client, client, require_admin_client
+from cartesia_mcp.credentials import configure_stdio_credentials
+from cartesia_mcp.hosted import fastmcp_hosted_kwargs, hosted_enabled, run_hosted
 from cartesia_mcp.request_options import sdk_kwargs_from_request_options
-from cartesia_mcp.sdk_setup import create_cartesia_client
 from cartesia_mcp.utils import (
     create_output_file,
     cursor_page_to_result,
@@ -46,24 +50,25 @@ from cartesia_mcp.utils import (
 
 load_dotenv()
 
+_is_hosted = hosted_enabled() or (
+    "--transport" in sys.argv and "streamable-http" in sys.argv
+)
 CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY = validate_api_keys(
     env_or_none("CARTESIA_API_KEY"),
     env_or_none("CARTESIA_ADMIN_API_KEY"),
+    require_api_key=not _is_hosted,
 )
 
 OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
-client = create_cartesia_client(CARTESIA_API_KEY)
-admin_client = (
-    create_cartesia_client(CARTESIA_ADMIN_API_KEY)
-    if CARTESIA_ADMIN_API_KEY
-    else None
-)
-mcp = FastMCP("Cartesia")
+if CARTESIA_API_KEY:
+    configure_stdio_credentials(CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY)
+
+mcp = FastMCP("Cartesia", **(fastmcp_hosted_kwargs() if _is_hosted else {}))
 
 
 def _require_admin_client() -> Cartesia:
-    return ensure_admin_client(admin_client)
+    return require_admin_client()
 
 
 def _build_generation_config(
@@ -841,6 +846,20 @@ def delete_pronunciation_dict(dict_id: str) -> DeletePronunciationDictResult:
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Cartesia MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="streamable-http" if _is_hosted else "stdio",
+    )
+    args = parser.parse_args()
+
+    if args.transport == "streamable-http":
+        run_hosted(mcp)
+        return
+
+    if not CARTESIA_API_KEY:
+        raise ValueError("CARTESIA_API_KEY is required for stdio transport")
     mcp.run(transport="stdio")
 
 if __name__ == "__main__":

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -38,7 +38,7 @@ from cartesia_mcp import extra_api
 from cartesia_mcp.extra_api import UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
 from cartesia_mcp.clients import admin_client, client, require_admin_client
-from cartesia_mcp.credentials import configure_stdio_credentials
+from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
 from cartesia_mcp.hosted import fastmcp_hosted_kwargs, hosted_enabled, run_hosted
 from cartesia_mcp.request_options import sdk_kwargs_from_request_options
 from cartesia_mcp.utils import (
@@ -61,7 +61,9 @@ CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY = validate_api_keys(
 
 OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
-if CARTESIA_API_KEY:
+if _is_hosted:
+    configure_hosted_mode()
+elif CARTESIA_API_KEY:
     configure_stdio_credentials(CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY)
 
 mcp = FastMCP("Cartesia", **(fastmcp_hosted_kwargs() if _is_hosted else {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">=3.13"
 dependencies = [
     "cartesia[websockets]>=3.2.0,<4.0.0",
     "httpx>=0.28.1",
-    "mcp[cli]>=1.7.1",
+    "mcp[cli]>=1.27.0",
+    "python-dotenv>=1.0.0",
+    "uvicorn>=0.34.0",
 ]
 
 [project.scripts]

--- a/tests/test_hosted_credentials.py
+++ b/tests/test_hosted_credentials.py
@@ -1,0 +1,39 @@
+"""Tests for hosted MCP credential resolution."""
+
+import pytest
+
+from cartesia_mcp.credentials import (
+    configure_stdio_credentials,
+    is_valid_bearer_credential,
+    looks_like_cartesia_access_token,
+    looks_like_cartesia_api_key,
+    resolve_api_credential,
+)
+
+
+def test_api_key_detection():
+    assert looks_like_cartesia_api_key("sk_car_abc.def")
+    assert not looks_like_cartesia_api_key("sk_car_admin_abc.def")
+
+
+def test_access_token_detection():
+    assert looks_like_cartesia_access_token("eyJhbGciOiJIUzI1NiJ9.payload.sig")
+
+
+def test_valid_bearer_credential():
+    assert is_valid_bearer_credential("sk_car_abc.def")
+    assert is_valid_bearer_credential("eyJhbGciOiJIUzI1NiJ9.x.y")
+    assert not is_valid_bearer_credential("sk_car_admin_abc.def")
+
+
+def test_stdio_credential_resolution():
+    configure_stdio_credentials("sk_car_test.key", None)
+    assert resolve_api_credential() == "sk_car_test.key"
+
+
+def test_missing_credential_raises():
+    configure_stdio_credentials("sk_car_test.key", None)
+    configure_stdio_credentials("", None)
+    with pytest.raises(ValueError, match="No Cartesia credential"):
+        resolve_api_credential()
+    configure_stdio_credentials("sk_car_test.key", None)

--- a/tests/test_hosted_credentials.py
+++ b/tests/test_hosted_credentials.py
@@ -3,11 +3,14 @@
 import pytest
 
 from cartesia_mcp.credentials import (
+    configure_hosted_mode,
     configure_stdio_credentials,
     is_valid_bearer_credential,
     looks_like_cartesia_access_token,
     looks_like_cartesia_api_key,
+    resolve_admin_api_credential,
     resolve_api_credential,
+    set_hosted_admin_credential,
 )
 
 
@@ -37,3 +40,22 @@ def test_missing_credential_raises():
     with pytest.raises(ValueError, match="No Cartesia credential"):
         resolve_api_credential()
     configure_stdio_credentials("sk_car_test.key", None)
+
+
+def test_hosted_admin_does_not_fall_back_to_stdio_env():
+    configure_stdio_credentials("sk_car_test.key", "sk_car_admin_test.key")
+    configure_hosted_mode()
+    set_hosted_admin_credential(None)
+    assert resolve_admin_api_credential() is None
+
+    set_hosted_admin_credential("sk_car_admin_oauth.key")
+    assert resolve_admin_api_credential() == "sk_car_admin_oauth.key"
+    set_hosted_admin_credential(None)
+    configure_hosted_mode(enabled=False)
+
+
+def test_stdio_admin_still_uses_env():
+    configure_hosted_mode(enabled=False)
+    set_hosted_admin_credential(None)
+    configure_stdio_credentials("sk_car_test.key", "sk_car_admin_test.key")
+    assert resolve_admin_api_credential() == "sk_car_admin_test.key"

--- a/tests/test_hosted_mode.py
+++ b/tests/test_hosted_mode.py
@@ -1,0 +1,18 @@
+"""Tests for hosted mode configuration."""
+
+from cartesia_mcp.hosted import hosted_enabled
+
+
+def test_hosted_enabled_parses_truthy_values(monkeypatch):
+    monkeypatch.delenv("MCP_HOSTED", raising=False)
+    assert hosted_enabled() is False
+
+    for value in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("MCP_HOSTED", value)
+        assert hosted_enabled() is True
+
+
+def test_hosted_enabled_rejects_falsey_values(monkeypatch):
+    for value in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv("MCP_HOSTED", value)
+        assert hosted_enabled() is False

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -1,0 +1,29 @@
+"""Tests for OAuth provider token loading."""
+
+import asyncio
+
+from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+from cartesia_mcp.oauth_store import StoredMcpAccessToken, oauth_store
+
+
+def test_mcp_oauth_access_token_resolves_before_jwt_heuristic():
+    oauth_store._mcp_tokens.clear()
+    mcp_token = "eyJmcp_oauth_access_token_example"
+    oauth_store._mcp_tokens[mcp_token] = StoredMcpAccessToken(
+        token=mcp_token,
+        cartesia_credential="eyJreal_cartesia_jwt",
+        client_id="test-client",
+        scopes=["mcp"],
+        expires_at=9999999999,
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    access = asyncio.run(provider.load_access_token(mcp_token))
+
+    assert access is not None
+    assert access.token == "eyJreal_cartesia_jwt"
+    assert access.client_id == "test-client"

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -141,3 +141,59 @@ def test_connect_token_required():
             completing_owner_id="org_test",
             completing_user_id="user_test",
         )
+
+
+def test_attach_credential_is_idempotent_for_same_payload():
+    oauth_store._pending.clear()
+    client = _client()
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+
+    first = oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    second = oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    assert second is first
+
+
+def test_completed_redirect_is_reused():
+    oauth_store._completed_redirects.clear()
+    oauth_store.remember_completed_redirect(
+        "session123",
+        "token456",
+        "org_test",
+        "user_test",
+        "cursor://callback?code=abc&state=xyz",
+    )
+    assert (
+        oauth_store.get_completed_redirect(
+            "session123",
+            "token456",
+            "org_test",
+            "user_test",
+        )
+        == "cursor://callback?code=abc&state=xyz"
+    )
+    assert (
+        oauth_store.get_completed_redirect(
+            "session123",
+            "wrong-token",
+            "org_test",
+            "user_test",
+        )
+        is None
+    )

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -1,6 +1,7 @@
 """Tests for OAuth store authorization code exchange."""
 
 from pydantic import AnyUrl
+import pytest
 
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
 from cartesia_mcp.oauth_store import oauth_store
@@ -18,6 +19,17 @@ def _client() -> OAuthClientInformationFull:
     )
 
 
+def _params() -> AuthorizationParams:
+    return AuthorizationParams(
+        state="state123",
+        scopes=["mcp"],
+        code_challenge="challenge",
+        redirect_uri=AnyUrl("cursor://callback"),
+        redirect_uri_provided_explicitly=True,
+        resource=None,
+    )
+
+
 def test_oauth_code_exchange_roundtrip():
     oauth_store._clients.clear()
     oauth_store._pending.clear()
@@ -26,16 +38,17 @@ def test_oauth_code_exchange_roundtrip():
 
     client = _client()
     oauth_store.register_client(client)
-    params = AuthorizationParams(
-        state="state123",
-        scopes=["mcp"],
-        code_challenge="challenge",
-        redirect_uri=AnyUrl("cursor://callback"),
-        redirect_uri_provided_explicitly=True,
-        resource=None,
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
     )
-    session_id = oauth_store.create_pending_session(client.client_id, params)
-    oauth_store.attach_credential(session_id, "eyJcartesia.token")
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
     pending = oauth_store.pop_pending(session_id)
 
     provider = CartesiaOAuthProvider(
@@ -66,18 +79,16 @@ def test_oauth_admin_credential_propagates_to_access_token():
 
     client = _client()
     oauth_store.register_client(client)
-    params = AuthorizationParams(
-        state="state123",
-        scopes=["mcp"],
-        code_challenge="challenge",
-        redirect_uri=AnyUrl("cursor://callback"),
-        redirect_uri_provided_explicitly=True,
-        resource=None,
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
     )
-    session_id = oauth_store.create_pending_session(client.client_id, params)
     oauth_store.attach_credential(
         session_id,
+        connect_token,
         "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
     )
     pending = oauth_store.pop_pending(session_id)
@@ -95,3 +106,38 @@ def test_oauth_admin_credential_propagates_to_access_token():
     loaded = oauth_store.resolve_mcp_access_token(token.access_token)
     assert loaded is not None
     assert loaded.cartesia_admin_credential == "sk_car_admin_test.key"
+
+
+def test_connect_token_required():
+    oauth_store._pending.clear()
+    client = _client()
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+
+    with pytest.raises(KeyError):
+        oauth_store.attach_credential(
+            session_id,
+            "wrong-token",
+            "eyJcartesia.token",
+            completing_owner_id="org_test",
+            completing_user_id="user_test",
+        )
+
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+
+    with pytest.raises(ValueError, match="already completed"):
+        oauth_store.attach_credential(
+            session_id,
+            connect_token,
+            "eyJother.token",
+            completing_owner_id="org_test",
+            completing_user_id="user_test",
+        )

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -56,3 +56,42 @@ def test_oauth_code_exchange_roundtrip():
     loaded = oauth_store.resolve_mcp_access_token(token.access_token)
     assert loaded is not None
     assert loaded.cartesia_credential == "eyJcartesia.token"
+
+
+def test_oauth_admin_credential_propagates_to_access_token():
+    oauth_store._clients.clear()
+    oauth_store._pending.clear()
+    oauth_store._auth_codes.clear()
+    oauth_store._mcp_tokens.clear()
+
+    client = _client()
+    oauth_store.register_client(client)
+    params = AuthorizationParams(
+        state="state123",
+        scopes=["mcp"],
+        code_challenge="challenge",
+        redirect_uri=AnyUrl("cursor://callback"),
+        redirect_uri_provided_explicitly=True,
+        resource=None,
+    )
+    session_id = oauth_store.create_pending_session(client.client_id, params)
+    oauth_store.attach_credential(
+        session_id,
+        "eyJcartesia.token",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    pending = oauth_store.pop_pending(session_id)
+
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code_value = redirect.split("code=")[1].split("&")[0]
+    auth_code = oauth_store.load_authorization_code(client, auth_code_value)
+    assert auth_code is not None
+
+    token = oauth_store.exchange_authorization_code(client, auth_code)
+    loaded = oauth_store.resolve_mcp_access_token(token.access_token)
+    assert loaded is not None
+    assert loaded.cartesia_admin_credential == "sk_car_admin_test.key"

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -1,0 +1,58 @@
+"""Tests for OAuth store authorization code exchange."""
+
+from pydantic import AnyUrl
+
+from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+from cartesia_mcp.oauth_store import oauth_store
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="test-client",
+        client_secret=None,
+        redirect_uris=[AnyUrl("cursor://callback")],
+        client_name="Test",
+        token_endpoint_auth_method="none",
+    )
+
+
+def test_oauth_code_exchange_roundtrip():
+    oauth_store._clients.clear()
+    oauth_store._pending.clear()
+    oauth_store._auth_codes.clear()
+    oauth_store._mcp_tokens.clear()
+
+    client = _client()
+    oauth_store.register_client(client)
+    params = AuthorizationParams(
+        state="state123",
+        scopes=["mcp"],
+        code_challenge="challenge",
+        redirect_uri=AnyUrl("cursor://callback"),
+        redirect_uri_provided_explicitly=True,
+        resource=None,
+    )
+    session_id = oauth_store.create_pending_session(client.client_id, params)
+    oauth_store.attach_credential(session_id, "eyJcartesia.token")
+    pending = oauth_store.pop_pending(session_id)
+
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    assert "code=" in redirect
+    assert "state=state123" in redirect
+
+    auth_code_value = redirect.split("code=")[1].split("&")[0]
+    auth_code = oauth_store.load_authorization_code(client, auth_code_value)
+    assert auth_code is not None
+
+    token = oauth_store.exchange_authorization_code(client, auth_code)
+    assert token.access_token
+
+    loaded = oauth_store.resolve_mcp_access_token(token.access_token)
+    assert loaded is not None
+    assert loaded.cartesia_credential == "eyJcartesia.token"

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -170,30 +170,69 @@ def test_attach_credential_is_idempotent_for_same_payload():
     assert second is first
 
 
-def test_completed_redirect_is_reused():
-    oauth_store._completed_redirects.clear()
-    oauth_store.remember_completed_redirect(
-        "session123",
-        "token456",
+def test_attach_credential_allows_admin_upgrade_on_retry():
+    oauth_store._pending.clear()
+    client = _client()
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    updated = oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    assert updated.cartesia_admin_credential == "sk_car_admin_test.key"
+
+
+def test_completed_session_retries_issue_fresh_code():
+    oauth_store._completed_sessions.clear()
+    oauth_store._auth_codes.clear()
+    oauth_store._mcp_tokens.clear()
+    client = _client()
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    pending = oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "eyJcartesia.token",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    oauth_store.remember_completed_session(
+        session_id,
+        connect_token,
         "org_test",
         "user_test",
-        "cursor://callback?code=abc&state=xyz",
+        pending,
     )
-    assert (
-        oauth_store.get_completed_redirect(
-            "session123",
-            "token456",
+
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    first = provider.build_resume_redirect(session_id, pending)
+    second = provider.build_resume_redirect(
+        session_id,
+        oauth_store.get_completed_session(
+            session_id,
+            connect_token,
             "org_test",
             "user_test",
-        )
-        == "cursor://callback?code=abc&state=xyz"
+        ),
     )
-    assert (
-        oauth_store.get_completed_redirect(
-            "session123",
-            "wrong-token",
-            "org_test",
-            "user_test",
-        )
-        is None
-    )
+    assert first != second
+    assert "code=" in second

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,21 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -25,6 +40,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "cartesia"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -32,7 +56,8 @@ dependencies = [
     { name = "anyio" },
     { name = "distro" },
     { name = "httpx" },
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
@@ -48,12 +73,14 @@ websockets = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia", extra = ["websockets"] },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "python-dotenv" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -65,7 +92,9 @@ dev = [
 requires-dist = [
     { name = "cartesia", extras = ["websockets"], specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.7.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -78,6 +107,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -99,6 +173,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -175,6 +299,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -188,22 +339,29 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.7.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "httpx-sse" },
-    { name = "pydantic" },
+    { name = "jsonschema" },
+    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
-    { name = "starlette" },
+    { name = "starlette", version = "0.46.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ae/588691c45b38f4fbac07fa3d6d50cea44cc6b35d16ddfdf26e17a0467ab2/mcp-1.7.1.tar.gz", hash = "sha256:eb4f1f53bd717f75dda8a1416e00804b831a8f3c331e23447a03b78f04b43a6e", size = 230903, upload-time = "2025-05-02T17:01:56.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/79/fe0e20c3358997a80911af51bad927b5ea2f343ef95ab092b19c9cc48b59/mcp-1.7.1-py3-none-any.whl", hash = "sha256:f7e6108977db6d03418495426c7ace085ba2341b75197f8727f96f9cfd30057a", size = 100365, upload-time = "2025-05-02T17:01:54.674Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -240,14 +398,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version < '3.14'" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540, upload-time = "2025-04-29T20:38:55.02Z" }
 wheels = [
@@ -255,11 +426,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "annotated-types", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -283,11 +477,72 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
@@ -303,6 +558,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -340,6 +609,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -350,6 +648,101 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -376,7 +769,8 @@ version = "2.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "starlette" },
+    { name = "starlette", version = "0.46.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/be/7e776a29b5f712b5bd13c571256a2470fcf345c562c7b2359f2ee15d9355/sse_starlette-2.3.4.tar.gz", hash = "sha256:0ffd6bed217cdbb74a84816437c609278003998b4991cd2e6872d0b35130e4d5", size = 17522, upload-time = "2025-05-04T19:28:51.44Z" }
 wheels = [
@@ -387,8 +781,12 @@ wheels = [
 name = "starlette"
 version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
@@ -396,18 +794,34 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "typer"
-version = "0.15.3"
+version = "0.26.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/1a/5f36851f439884bcfe8539f6a20ff7516e7b60f319bbaf69a90dc35cc2eb/typer-0.15.3.tar.gz", hash = "sha256:818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c", size = 101641, upload-time = "2025-04-28T21:40:59.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/20/9d953de6f4367163d23ec823200eb3ecb0050a2609691e512c8b95827a9b/typer-0.15.3-py3-none-any.whl", hash = "sha256:c86a65ad77ca531f03de08d1b9cb67cd09ad02ddddf4b34745b5008f43b239bd", size = 45253, upload-time = "2025-04-28T21:40:56.269Z" },
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]
@@ -421,14 +835,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload-time = "2025-02-25T17:27:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1281/render-service-dockerfile-for-hosted-mcp
Fixes https://linear.app/cartesia/issue/SUR-1282/hosted-mcp-http-server-with-per-request-bearer-auth

## Summary

Hosted Streamable HTTP MCP for `mcp.cartesia.ai` with OAuth connect via the playground. Stdio mode (`uvx cartesia-mcp` + `CARTESIA_API_KEY`) is unchanged.

## Changes

- Dockerfile + `MCP_HOSTED=1` entrypoint for Render
- Per-request credentials (OAuth, bearer JWT/API key); stdio env unchanged
- OAuth: `/mcp/connect?session=…&token=…` → `POST /internal/oauth/complete`
- `connect_token` + org/user binding; idempotent complete retries
- No process-level admin key fallback in hosted mode
- `uv run pytest` (49 tests)

## Merge order

Merge **before** [product #3197](https://github.com/cartesia-ai/product/pull/3197).

## Deploy / test

- [ ] Merge → Render builds from this repo
- [ ] `GET /health` on `mcp.cartesia.ai`
- [ ] Set `MCP_INTERNAL_SECRET` + DNS, then E2E OAuth from Cursor (with product #3197)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New authentication and OAuth flows handle user credentials and admin keys; hosted mode changes how keys are resolved at runtime. In-memory OAuth state is single-process only until replaced for scale.
> 
> **Overview**
> Adds a **hosted deployment path** for the Cartesia MCP server: a Dockerfile (`MCP_HOSTED=1`, streamable-http on port 8000), CI job that builds the image and smoke-tests `GET /health`, and a `--transport` CLI switch between stdio and streamable-http.
> 
> **Credential model** is refactored so tools no longer use a single process-wide SDK client. Lazy proxies resolve Cartesia API keys per request from MCP auth context (OAuth/bearer) or from stdio env configuration; hosted mode skips requiring `CARTESIA_API_KEY` at startup and does not fall back to env for admin keys—admin credentials come from OAuth via a context var.
> 
> **OAuth for hosted MCP** wires FastMCP auth (dynamic client registration, `mcp` scope) to a playground redirect flow, an in-memory store for pending/completed connect sessions, and `POST /internal/oauth/complete` (protected by `MCP_INTERNAL_SECRET`) for the playground to attach user credentials and return the OAuth redirect. Direct bearer JWT/API keys remain accepted when valid.
> 
> Dependencies bump `mcp` to ≥1.27.0 and add explicit `python-dotenv` / `uvicorn`; new pytest coverage targets credentials, hosted flags, OAuth store/provider behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a6d40b0f793c228cf0bd29007527266df984dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->