### PR TITLE
test: assert REST attribution and require API keys for hosted OAuth

### DIFF
--- a/cartesia_mcp/credentials.py
+++ b/cartesia_mcp/credentials.py
@@ -68,11 +68,5 @@ def looks_like_cartesia_api_key(token: str) -> bool:
     return token.startswith("sk_car_") and not token.startswith("sk_car_admin_")
 
 
-def looks_like_cartesia_access_token(token: str) -> bool:
-    return token.startswith("eyJ")
-
-
 def is_valid_bearer_credential(token: str) -> bool:
-    if looks_like_cartesia_api_key(token):
-        return not is_admin_api_key(token)
-    return looks_like_cartesia_access_token(token)
+    return looks_like_cartesia_api_key(token) and not is_admin_api_key(token)

--- a/cartesia_mcp/sdk_setup.py
+++ b/cartesia_mcp/sdk_setup.py
@@ -15,11 +15,15 @@ def is_admin_api_key(api_key: str) -> bool:
     return api_key.startswith(ADMIN_API_KEY_PREFIX)
 
 
-def create_cartesia_client(api_key: str) -> Cartesia:
-    return Cartesia(
-        api_key=api_key,
-        default_headers={
-            "cartesia-version": CARTESIA_VERSION,
-            **client_request_headers(),
-        },
-    )
+def _looks_like_cartesia_access_token(credential: str) -> bool:
+    return credential.startswith("eyJ")
+
+
+def create_cartesia_client(credential: str) -> Cartesia:
+    headers = {
+        "cartesia-version": CARTESIA_VERSION,
+        **client_request_headers(),
+    }
+    if _looks_like_cartesia_access_token(credential):
+        return Cartesia(token=credential, default_headers=headers)
+    return Cartesia(api_key=credential, default_headers=headers)

--- a/cartesia_mcp/sdk_setup.py
+++ b/cartesia_mcp/sdk_setup.py
@@ -15,15 +15,11 @@ def is_admin_api_key(api_key: str) -> bool:
     return api_key.startswith(ADMIN_API_KEY_PREFIX)
 
 
-def _looks_like_cartesia_access_token(credential: str) -> bool:
-    return credential.startswith("eyJ")
-
-
-def create_cartesia_client(credential: str) -> Cartesia:
-    headers = {
-        "cartesia-version": CARTESIA_VERSION,
-        **client_request_headers(),
-    }
-    if _looks_like_cartesia_access_token(credential):
-        return Cartesia(token=credential, default_headers=headers)
-    return Cartesia(api_key=credential, default_headers=headers)
+def create_cartesia_client(api_key: str) -> Cartesia:
+    return Cartesia(
+        api_key=api_key,
+        default_headers={
+            "cartesia-version": CARTESIA_VERSION,
+            **client_request_headers(),
+        },
+    )

--- a/tests/test_client_attribution.py
+++ b/tests/test_client_attribution.py
@@ -16,14 +16,6 @@ def test_create_cartesia_client_default_headers_match_attribution() -> None:
     assert client.default_headers["X-Cartesia-Client"] == header
 
 
-def test_create_cartesia_client_uses_token_auth_for_jwt_credentials() -> None:
-    jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test"
-    client = create_cartesia_client(jwt)
-
-    assert client.token == jwt
-    assert client.api_key is None
-
-
 def test_rest_httpx_identifies_as_cartesia_mcp() -> None:
     from cartesia._models import FinalRequestOptions
 

--- a/tests/test_client_attribution.py
+++ b/tests/test_client_attribution.py
@@ -16,6 +16,25 @@ def test_create_cartesia_client_default_headers_match_attribution() -> None:
     assert client.default_headers["X-Cartesia-Client"] == header
 
 
+def test_create_cartesia_client_uses_token_auth_for_jwt_credentials() -> None:
+    jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test"
+    client = create_cartesia_client(jwt)
+
+    assert client.token == jwt
+    assert client.api_key is None
+
+
+def test_rest_httpx_identifies_as_cartesia_mcp() -> None:
+    from cartesia._models import FinalRequestOptions
+
+    client = create_cartesia_client("sk_car_test_key")
+    request = client._build_request(FinalRequestOptions(method="get", url="/voices"))
+
+    header = client_header()
+    assert request.headers["User-Agent"] == header
+    assert request.headers["X-Cartesia-Client"] == header
+
+
 def test_stt_auto_finalize_connect_merges_default_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     client = create_cartesia_client("sk_car_test_key")
     captured: dict[str, object] = {}

--- a/tests/test_hosted_credentials.py
+++ b/tests/test_hosted_credentials.py
@@ -6,7 +6,6 @@ from cartesia_mcp.credentials import (
     configure_hosted_mode,
     configure_stdio_credentials,
     is_valid_bearer_credential,
-    looks_like_cartesia_access_token,
     looks_like_cartesia_api_key,
     resolve_admin_api_credential,
     resolve_api_credential,
@@ -19,13 +18,9 @@ def test_api_key_detection():
     assert not looks_like_cartesia_api_key("sk_car_admin_abc.def")
 
 
-def test_access_token_detection():
-    assert looks_like_cartesia_access_token("eyJhbGciOiJIUzI1NiJ9.payload.sig")
-
-
 def test_valid_bearer_credential():
     assert is_valid_bearer_credential("sk_car_abc.def")
-    assert is_valid_bearer_credential("eyJhbGciOiJIUzI1NiJ9.x.y")
+    assert not is_valid_bearer_credential("eyJhbGciOiJIUzI1NiJ9.x.y")
     assert not is_valid_bearer_credential("sk_car_admin_abc.def")
 
 

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -6,12 +6,12 @@ from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
 from cartesia_mcp.oauth_store import StoredMcpAccessToken, oauth_store
 
 
-def test_mcp_oauth_access_token_resolves_before_jwt_heuristic():
+def test_mcp_oauth_access_token_resolves_stored_credential():
     oauth_store._mcp_tokens.clear()
-    mcp_token = "eyJmcp_oauth_access_token_example"
+    mcp_token = "mcp_oauth_access_token_example"
     oauth_store._mcp_tokens[mcp_token] = StoredMcpAccessToken(
         token=mcp_token,
-        cartesia_credential="eyJreal_cartesia_jwt",
+        cartesia_credential="sk_car_oauth_test_key",
         client_id="test-client",
         scopes=["mcp"],
         expires_at=9999999999,
@@ -25,5 +25,5 @@ def test_mcp_oauth_access_token_resolves_before_jwt_heuristic():
     access = asyncio.run(provider.load_access_token(mcp_token))
 
     assert access is not None
-    assert access.token == "eyJreal_cartesia_jwt"
+    assert access.token == "sk_car_oauth_test_key"
     assert access.client_id == "test-client"

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -45,7 +45,7 @@ def test_oauth_code_exchange_roundtrip():
     oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
     )
@@ -68,7 +68,7 @@ def test_oauth_code_exchange_roundtrip():
 
     loaded = oauth_store.resolve_mcp_access_token(token.access_token)
     assert loaded is not None
-    assert loaded.cartesia_credential == "eyJcartesia.token"
+    assert loaded.cartesia_credential == "sk_car_oauth_test_key"
 
 
 def test_oauth_admin_credential_propagates_to_access_token():
@@ -86,7 +86,7 @@ def test_oauth_admin_credential_propagates_to_access_token():
     oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
@@ -120,7 +120,7 @@ def test_connect_token_required():
         oauth_store.attach_credential(
             session_id,
             "wrong-token",
-            "eyJcartesia.token",
+            "sk_car_oauth_test_key",
             completing_owner_id="org_test",
             completing_user_id="user_test",
         )
@@ -128,7 +128,7 @@ def test_connect_token_required():
     oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
     )
@@ -137,7 +137,7 @@ def test_connect_token_required():
         oauth_store.attach_credential(
             session_id,
             connect_token,
-            "eyJother.token",
+            "sk_car_other_test_key",
             completing_owner_id="org_test",
             completing_user_id="user_test",
         )
@@ -154,7 +154,7 @@ def test_attach_credential_is_idempotent_for_same_payload():
     first = oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
@@ -162,7 +162,7 @@ def test_attach_credential_is_idempotent_for_same_payload():
     second = oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
@@ -181,14 +181,14 @@ def test_attach_credential_allows_admin_upgrade_on_retry():
     oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
     )
     updated = oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
@@ -208,7 +208,7 @@ def test_completed_session_retries_issue_fresh_code():
     pending = oauth_store.attach_credential(
         session_id,
         connect_token,
-        "eyJcartesia.token",
+        "sk_car_oauth_test_key",
         completing_owner_id="org_test",
         completing_user_id="user_test",
     )


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1282/hosted-mcp-http-server-with-per-request-bearer-auth

## Summary

Follow-up hardening after [product #3211](https://github.com/cartesia-ai/product/pull/3211) merged — hosted OAuth now stores `sk_car_...` API keys instead of JWTs. This PR aligns cartesia-mcp with that contract: drop JWT bearer acceptance, update OAuth test fixtures to use API keys, and add a regression test that REST requests carry `cartesia-mcp/<version>` attribution headers.

## Changes

- Remove `looks_like_cartesia_access_token` and JWT acceptance from `is_valid_bearer_credential`
- Update OAuth store/provider tests to use `sk_car_...` credentials instead of `eyJ...` JWTs
- Add `test_rest_httpx_identifies_as_cartesia_mcp` asserting `_build_request` sets `User-Agent` and `X-Cartesia-Client`

## Test plan

- [x] `uv run pytest tests/test_client_attribution.py tests/test_hosted_credentials.py tests/test_oauth_provider.py tests/test_oauth_store.py`
- [ ] After deploy, reconnect MCP and confirm Datadog attribution on hosted tool calls