### PR TITLE
feat: hide admin-only MCP tools without admin credential

### DIFF
--- a/cartesia_mcp/fastmcp_server.py
+++ b/cartesia_mcp/fastmcp_server.py
@@ -1,0 +1,14 @@
+"""Cartesia FastMCP server with session-aware tool listing."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import Tool as MCPTool
+
+from cartesia_mcp.tool_visibility import is_tool_visible
+
+
+class CartesiaMCP(FastMCP):
+    async def list_tools(self) -> list[MCPTool]:
+        tools = await super().list_tools()
+        return [tool for tool in tools if is_tool_visible(tool.name)]

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -7,7 +7,6 @@ import os
 import sys
 import typing
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from cartesia import Cartesia, RequestOptions, omit
 from cartesia.types import (
@@ -40,6 +39,7 @@ from cartesia_mcp.extra_api import UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
 from cartesia_mcp.clients import admin_client, client, require_admin_client
 from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
+from cartesia_mcp.fastmcp_server import CartesiaMCP
 from cartesia_mcp.hosted import fastmcp_hosted_kwargs, hosted_enabled, run_hosted
 from cartesia_mcp.request_options import sdk_kwargs_from_request_options
 from cartesia_mcp.utils import (
@@ -67,7 +67,7 @@ if _is_hosted:
 elif CARTESIA_API_KEY:
     configure_stdio_credentials(CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY)
 
-mcp = FastMCP("Cartesia", **(fastmcp_hosted_kwargs() if _is_hosted else {}))
+mcp = CartesiaMCP("Cartesia", **(fastmcp_hosted_kwargs() if _is_hosted else {}))
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True)
 _WRITE = ToolAnnotations(destructiveHint=True)

--- a/cartesia_mcp/tool_visibility.py
+++ b/cartesia_mcp/tool_visibility.py
@@ -1,0 +1,17 @@
+"""Session-scoped visibility for admin-only MCP tools."""
+
+from __future__ import annotations
+
+from cartesia_mcp.credentials import resolve_admin_api_credential
+
+ADMIN_ONLY_TOOLS = frozenset({"get_credit_usage"})
+
+
+def admin_tools_available() -> bool:
+    return resolve_admin_api_credential() is not None
+
+
+def is_tool_visible(tool_name: str) -> bool:
+    if tool_name in ADMIN_ONLY_TOOLS:
+        return admin_tools_available()
+    return True

--- a/tests/test_tool_visibility.py
+++ b/tests/test_tool_visibility.py
@@ -1,0 +1,57 @@
+"""Tests for admin-only tool visibility in MCP tool listings."""
+
+from __future__ import annotations
+
+import asyncio
+
+import cartesia_mcp.server as server
+from cartesia_mcp.tool_visibility import (
+    ADMIN_ONLY_TOOLS,
+    admin_tools_available,
+    is_tool_visible,
+)
+
+
+def test_admin_only_tools_constant():
+    assert ADMIN_ONLY_TOOLS == frozenset({"get_credit_usage"})
+
+
+def test_is_tool_visible_hides_admin_tools_without_credential(monkeypatch):
+    monkeypatch.setattr(
+        "cartesia_mcp.tool_visibility.resolve_admin_api_credential",
+        lambda: None,
+    )
+    assert admin_tools_available() is False
+    assert is_tool_visible("list_voices") is True
+    assert is_tool_visible("get_credit_usage") is False
+
+
+def test_is_tool_visible_shows_admin_tools_with_credential(monkeypatch):
+    monkeypatch.setattr(
+        "cartesia_mcp.tool_visibility.resolve_admin_api_credential",
+        lambda: "sk_car_admin_test.key",
+    )
+    assert admin_tools_available() is True
+    assert is_tool_visible("get_credit_usage") is True
+
+
+def test_list_tools_hides_admin_tools_without_credential(monkeypatch):
+    monkeypatch.setattr(
+        "cartesia_mcp.tool_visibility.resolve_admin_api_credential",
+        lambda: None,
+    )
+    tools = asyncio.run(server.mcp.list_tools())
+    names = {tool.name for tool in tools}
+    assert len(names) == 14
+    assert "get_credit_usage" not in names
+
+
+def test_list_tools_shows_admin_tools_with_credential(monkeypatch):
+    monkeypatch.setattr(
+        "cartesia_mcp.tool_visibility.resolve_admin_api_credential",
+        lambda: "sk_car_admin_test.key",
+    )
+    tools = asyncio.run(server.mcp.list_tools())
+    names = {tool.name for tool in tools}
+    assert len(names) == 15
+    assert "get_credit_usage" in names


### PR DESCRIPTION
## Summary

Hides `get_credit_usage` from MCP `tools/list` unless the session has an admin API key. Hosted OAuth users only see billing tools after opting in on the Playground connect page; stdio users need `CARTESIA_ADMIN_API_KEY`.

## Changes

- Add `tool_visibility` helper and `CartesiaMCP` subclass that filters `list_tools` output
- Switch server to `CartesiaMCP` instead of plain `FastMCP`
- Add tests for visibility logic and filtered tool listings

## Test plan

- [x] `uv run pytest`
- [ ] Connect without admin tools enabled → Claude shows 14 tools (5 read-only, 9 write)
- [ ] Reconnect with admin tools enabled → `get_credit_usage` appears under read-only