### PR TITLE
feat: add MCP tools for files API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,9 @@ Ask your agent things like:
 | `get_pronunciation_dict` | Get a pronunciation dictionary by ID |
 | `update_pronunciation_dict` | Update a pronunciation dictionary |
 | `delete_pronunciation_dict` | Delete a pronunciation dictionary |
-| `list_files` | List files in cloud storage (`GET /files`) |
-| `get_file` | Get file metadata (`GET /files/{id}/info`) |
-| `download_file` | Download a file to the local output directory |
-| `upload_file` | Upload a local file to cloud storage (`POST /files`) |
-| `delete_file` | Delete a file from cloud storage (`DELETE /files/{id}`) |
+| `list_files` | List Cartesia cloud-stored files (e.g. `tts_generation` history) |
+| `get_file` | Get cloud file metadata (`GET /files/{id}/info`) |
+| `download_file` | Download a cloud-stored file to the local output directory |
 | `get_credit_usage` | Credit usage over time (`CARTESIA_ADMIN_API_KEY`) |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Ask your agent things like:
 | `get_pronunciation_dict` | Get a pronunciation dictionary by ID |
 | `update_pronunciation_dict` | Update a pronunciation dictionary |
 | `delete_pronunciation_dict` | Delete a pronunciation dictionary |
+| `list_files` | List cloud-stored files (filter by purpose, e.g. `tts_generation`) |
+| `get_file` | Get cloud file metadata by ID |
+| `download_file` | Download a cloud file to the local output directory |
 | `get_credit_usage` | Credit usage over time (`CARTESIA_ADMIN_API_KEY`) |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Ask your agent things like:
 | `get_pronunciation_dict` | Get a pronunciation dictionary by ID |
 | `update_pronunciation_dict` | Update a pronunciation dictionary |
 | `delete_pronunciation_dict` | Delete a pronunciation dictionary |
-| `list_files` | List cloud-stored files (filter by purpose, e.g. `tts_generation`) |
-| `get_file` | Get cloud file metadata by ID |
-| `download_file` | Download a cloud file to the local output directory |
+| `list_files` | List files in cloud storage (`GET /files`) |
+| `get_file` | Get file metadata (`GET /files/{id}/info`) |
+| `download_file` | Download a file to the local output directory |
+| `upload_file` | Upload a local file to cloud storage (`POST /files`) |
+| `delete_file` | Delete a file from cloud storage (`DELETE /files/{id}`) |
 | `get_credit_usage` | Credit usage over time (`CARTESIA_ADMIN_API_KEY`) |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.

--- a/cartesia_mcp/custom_types/__init__.py
+++ b/cartesia_mcp/custom_types/__init__.py
@@ -6,7 +6,6 @@ from .pronunciation import (
 from .tool_results import (
     DownloadedFileResult,
     GeneratedAudioResult,
-    DeleteFileResult,
     DeleteVoiceResult,
     ListFilesResult,
     ListVoicesResult,
@@ -15,7 +14,6 @@ from .tool_type import ToolType
 
 __all__ = [
     "DeletePronunciationDictResult",
-    "DeleteFileResult",
     "DownloadedFileResult",
     "GeneratedAudioResult",
     "DeleteVoiceResult",

--- a/cartesia_mcp/custom_types/__init__.py
+++ b/cartesia_mcp/custom_types/__init__.py
@@ -6,6 +6,7 @@ from .pronunciation import (
 from .tool_results import (
     DownloadedFileResult,
     GeneratedAudioResult,
+    DeleteFileResult,
     DeleteVoiceResult,
     ListFilesResult,
     ListVoicesResult,
@@ -14,6 +15,7 @@ from .tool_type import ToolType
 
 __all__ = [
     "DeletePronunciationDictResult",
+    "DeleteFileResult",
     "DownloadedFileResult",
     "GeneratedAudioResult",
     "DeleteVoiceResult",

--- a/cartesia_mcp/custom_types/__init__.py
+++ b/cartesia_mcp/custom_types/__init__.py
@@ -3,13 +3,21 @@ from .pronunciation import (
     ListPronunciationDictsResult,
     PronunciationDictItemParams,
 )
-from .tool_results import GeneratedAudioResult, DeleteVoiceResult, ListVoicesResult
+from .tool_results import (
+    DownloadedFileResult,
+    GeneratedAudioResult,
+    DeleteVoiceResult,
+    ListFilesResult,
+    ListVoicesResult,
+)
 from .tool_type import ToolType
 
 __all__ = [
     "DeletePronunciationDictResult",
+    "DownloadedFileResult",
     "GeneratedAudioResult",
     "DeleteVoiceResult",
+    "ListFilesResult",
     "ListPronunciationDictsResult",
     "ListVoicesResult",
     "PronunciationDictItemParams",

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -5,6 +5,10 @@ class DeleteVoiceResult(typing.TypedDict):
     success: bool
 
 
+class DeleteFileResult(typing.TypedDict):
+    success: bool
+
+
 class GeneratedAudioResult(typing.TypedDict):
     file_path: str
 

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -9,6 +9,17 @@ class GeneratedAudioResult(typing.TypedDict):
     file_path: str
 
 
+class DownloadedFileResult(typing.TypedDict):
+    file_path: str
+    file_id: str
+    filename: str
+
+
+class ListFilesResult(typing.TypedDict, total=False):
+    data: typing.List[typing.Any]
+    has_more: bool
+
+
 class ListVoicesResult(typing.TypedDict, total=False):
     data: typing.List[typing.Any]
     has_more: bool

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -5,10 +5,6 @@ class DeleteVoiceResult(typing.TypedDict):
     success: bool
 
 
-class DeleteFileResult(typing.TypedDict):
-    success: bool
-
-
 class GeneratedAudioResult(typing.TypedDict):
     file_path: str
 

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -107,28 +107,3 @@ def list_files(
         cast_to=dict[str, typing.Any],
         options={"params": params} if params else None,
     )
-
-
-def upload_file(
-    client: Cartesia,
-    *,
-    file_path: str,
-    purpose: FilePurpose,
-) -> dict[str, typing.Any]:
-    from pathlib import Path
-
-    path = Path(file_path)
-    with path.open("rb") as file_obj:
-        return client.post(
-            _files_url("/files"),
-            cast_to=dict[str, typing.Any],
-            body={"purpose": purpose},
-            files=[("file", (path.name, file_obj))],
-        )
-
-
-def delete_file(client: Cartesia, file_id: str) -> dict[str, typing.Any]:
-    return client.delete(
-        _files_url(f"/files/{file_id}"),
-        cast_to=dict[str, typing.Any],
-    )

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -3,15 +3,42 @@ HTTP helpers for Cartesia endpoints not generated on the Python SDK.
 
 `get_usage_credits` must be called with a client authenticated using an admin API key
 (`CARTESIA_ADMIN_API_KEY`); standard API keys are rejected on `/usage/*`.
+
+Files helpers call `files.cartesia.ai` (override with `CARTESIA_FILES_BASE_URL`).
 """
 
 from __future__ import annotations
 
+import os
 import typing
 
 from cartesia import Cartesia
 
+from cartesia_mcp.config import env_or_none
+
 UsageInterval = typing.Literal["day", "week", "month"]
+DownloadFormat = typing.Literal["playback"]
+FilePurpose = typing.Literal[
+    "agent_background_sound",
+    "agent_source_archive",
+    "fine_tune",
+    "narration_export",
+    "original-audio-clip",
+    "synthetic-conditioning-audio",
+    "tts_generation",
+    "voice-clone",
+    "voice_sample",
+]
+
+DEFAULT_FILES_BASE_URL = "https://files.cartesia.ai"
+
+
+def files_base_url() -> str:
+    return env_or_none("CARTESIA_FILES_BASE_URL", os.environ) or DEFAULT_FILES_BASE_URL
+
+
+def _files_url(path: str) -> str:
+    return f"{files_base_url().rstrip('/')}{path}"
 
 
 def get_usage_credits(
@@ -35,4 +62,48 @@ def get_usage_credits(
         "/usage/credits",
         cast_to=dict[str, typing.Any],
         options={"params": params},
+    )
+
+
+def get_file_info(client: Cartesia, file_id: str) -> dict[str, typing.Any]:
+    return client.get(
+        _files_url(f"/files/{file_id}/info"),
+        cast_to=dict[str, typing.Any],
+    )
+
+
+def download_file_bytes(
+    client: Cartesia,
+    file_id: str,
+    *,
+    format: typing.Optional[DownloadFormat] = None,
+) -> bytes:
+    params: dict[str, str] = {}
+    if format is not None:
+        params["format"] = format
+    return client.get(
+        _files_url(f"/files/{file_id}/download"),
+        cast_to=bytes,
+        options={"params": params} if params else None,
+    )
+
+
+def list_files(
+    client: Cartesia,
+    *,
+    limit: typing.Optional[int] = None,
+    purpose: typing.Optional[FilePurpose] = None,
+    query: typing.Optional[str] = None,
+) -> dict[str, typing.Any]:
+    params: dict[str, str] = {}
+    if limit is not None:
+        params["limit"] = str(limit)
+    if purpose is not None:
+        params["purpose"] = purpose
+    if query is not None:
+        params["q"] = query
+    return client.get(
+        _files_url("/files"),
+        cast_to=dict[str, typing.Any],
+        options={"params": params} if params else None,
     )

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -107,3 +107,28 @@ def list_files(
         cast_to=dict[str, typing.Any],
         options={"params": params} if params else None,
     )
+
+
+def upload_file(
+    client: Cartesia,
+    *,
+    file_path: str,
+    purpose: FilePurpose,
+) -> dict[str, typing.Any]:
+    from pathlib import Path
+
+    path = Path(file_path)
+    with path.open("rb") as file_obj:
+        return client.post(
+            _files_url("/files"),
+            cast_to=dict[str, typing.Any],
+            body={"purpose": purpose},
+            files=[("file", (path.name, file_obj))],
+        )
+
+
+def delete_file(client: Cartesia, file_id: str) -> dict[str, typing.Any]:
+    return client.delete(
+        _files_url(f"/files/{file_id}"),
+        cast_to=dict[str, typing.Any],
+    )

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -27,7 +27,6 @@ from cartesia.types.tts_generate_params import OutputFormat
 from cartesia.types.voice_specifier_param import VoiceSpecifierParam
 
 from cartesia_mcp.custom_types import (
-    DeleteFileResult,
     DeletePronunciationDictResult,
     DeleteVoiceResult,
     DownloadedFileResult,
@@ -761,7 +760,11 @@ def speech_to_text(
     title="List files",
     annotations=_READ_ONLY,
     description="""
-        List files in Cartesia cloud storage (`GET /files` on `files.cartesia.ai`).
+        List files stored by Cartesia for your org (`GET /files` on `files.cartesia.ai`).
+
+        Use to discover cloud-stored generations (e.g. playground TTS history with
+        `purpose=tts_generation`) before calling `download_file`. This is not a
+        generic upload target — use `text_to_speech` / `voice_change` to generate audio.
 
         Parameters
         ----------
@@ -809,8 +812,11 @@ def get_file(file_id: str) -> dict[str, typing.Any]:
     title="Download file",
     annotations=_READ_ONLY,
     description="""
-        Download a file from cloud storage to the local output directory
+        Download a Cartesia cloud-stored file to the local output directory
         (`GET /files/{id}/download` on `files.cartesia.ai`).
+
+        Typical use: pull a `tts_generation` or other org-owned asset for local
+        playback or `speech_to_text`.
 
         Parameters
         ----------
@@ -848,43 +854,6 @@ def download_file(
         file_id=file_id,
         filename=local_filename,
     )
-
-
-@mcp.tool(
-    title="Upload file",
-    annotations=_WRITE,
-    description="""
-        Upload a local file to Cartesia cloud storage (`POST /files` on `files.cartesia.ai`).
-
-        Parameters
-        ----------
-        file_path : str
-            Absolute path to the local file to upload.
-
-        purpose : FilePurpose
-            File purpose tag (e.g. `original-audio-clip`, `voice-clone`).
-        """)
-def upload_file(
-    file_path: str,
-    purpose: FilePurpose,
-) -> dict[str, typing.Any]:
-    return extra_api.upload_file(client, file_path=file_path, purpose=purpose)
-
-
-@mcp.tool(
-    title="Delete file",
-    annotations=_WRITE,
-    description="""
-        Delete a file from Cartesia cloud storage (`DELETE /files/{id}` on `files.cartesia.ai`).
-
-        Parameters
-        ----------
-        file_id : str
-            File ID to delete.
-        """)
-def delete_file(file_id: str) -> DeleteFileResult:
-    extra_api.delete_file(client, file_id)
-    return DeleteFileResult(success=True)
 
 
 @mcp.tool(

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -27,6 +27,7 @@ from cartesia.types.tts_generate_params import OutputFormat
 from cartesia.types.voice_specifier_param import VoiceSpecifierParam
 
 from cartesia_mcp.custom_types import (
+    DeleteFileResult,
     DeletePronunciationDictResult,
     DeleteVoiceResult,
     DownloadedFileResult,
@@ -756,13 +757,10 @@ def speech_to_text(
 
 
 @mcp.tool(
-    title="List cloud files",
+    title="List files",
     annotations=_READ_ONLY,
     description="""
-        List files stored in Cartesia cloud storage (`files.cartesia.ai`).
-
-        Use this to discover file IDs for TTS generations, voice samples, and other
-        uploaded assets before calling `download_file`.
+        List files in Cartesia cloud storage (`GET /files` on `files.cartesia.ai`).
 
         Parameters
         ----------
@@ -770,7 +768,7 @@ def speech_to_text(
             Number of files per page (1–100).
 
         purpose : typing.Optional[FilePurpose]
-            Filter by purpose, e.g. `tts_generation` for playground/API TTS outputs.
+            Filter by purpose (e.g. `tts_generation`, `voice-clone`, `voice_sample`).
 
         query : typing.Optional[str]
             Search by filename.
@@ -792,36 +790,34 @@ def list_files(
 
 
 @mcp.tool(
-    title="Get cloud file metadata",
+    title="Get file metadata",
     annotations=_READ_ONLY,
     description="""
-        Fetch metadata for a file in Cartesia cloud storage by ID.
+        Fetch file metadata (`GET /files/{id}/info` on `files.cartesia.ai`).
 
         Parameters
         ----------
         file_id : str
-            Cloud file ID (from TTS history, `list_files`, or API responses).
+            File ID.
         """)
 def get_file(file_id: str) -> dict[str, typing.Any]:
     return extra_api.get_file_info(client, file_id)
 
 
 @mcp.tool(
-    title="Download cloud file",
+    title="Download file",
     annotations=_READ_ONLY,
     description="""
-        Download a file from Cartesia cloud storage to the local output directory.
-
-        Use for TTS generations saved to cloud (`purpose=tts_generation`), voice
-        previews, and other files owned by the authenticated account.
+        Download a file from cloud storage to the local output directory
+        (`GET /files/{id}/download` on `files.cartesia.ai`).
 
         Parameters
         ----------
         file_id : str
-            Cloud file ID to download.
+            File ID to download.
 
         format : typing.Optional[DownloadFormat]
-            Pass `playback` to wrap raw PCM TTS output as WAV for local playback.
+            Pass `playback` to wrap raw PCM as WAV for local playback.
         """)
 def download_file(
     file_id: str,
@@ -845,6 +841,43 @@ def download_file(
         file_id=file_id,
         filename=Path(filename).name,
     )
+
+
+@mcp.tool(
+    title="Upload file",
+    annotations=_WRITE,
+    description="""
+        Upload a local file to Cartesia cloud storage (`POST /files` on `files.cartesia.ai`).
+
+        Parameters
+        ----------
+        file_path : str
+            Absolute path to the local file to upload.
+
+        purpose : FilePurpose
+            File purpose tag (e.g. `original-audio-clip`, `voice-clone`).
+        """)
+def upload_file(
+    file_path: str,
+    purpose: FilePurpose,
+) -> dict[str, typing.Any]:
+    return extra_api.upload_file(client, file_path=file_path, purpose=purpose)
+
+
+@mcp.tool(
+    title="Delete file",
+    annotations=_WRITE,
+    description="""
+        Delete a file from Cartesia cloud storage (`DELETE /files/{id}` on `files.cartesia.ai`).
+
+        Parameters
+        ----------
+        file_id : str
+            File ID to delete.
+        """)
+def delete_file(file_id: str) -> DeleteFileResult:
+    extra_api.delete_file(client, file_id)
+    return DeleteFileResult(success=True)
 
 
 @mcp.tool(

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -50,6 +50,7 @@ from cartesia_mcp.utils import (
     create_output_file,
     cursor_page_to_result,
     iter_stt_audio_chunks,
+    resolve_local_download_filename,
     save_downloaded_file,
     voice_list_page_to_result,
 )
@@ -828,18 +829,24 @@ def download_file(
     if not isinstance(filename, str) or not filename.strip():
         filename = file_id
 
+    local_filename = resolve_local_download_filename(
+        filename,
+        file_id,
+        as_wav=format == "playback",
+    )
+
     content = extra_api.download_file_bytes(client, file_id, format=format)
     output_path = save_downloaded_file(
         OUTPUT_DIRECTORY,
         file_id=file_id,
-        filename=filename,
+        filename=local_filename,
         content=content,
     )
 
     return DownloadedFileResult(
         file_path=str(output_path),
         file_id=file_id,
-        filename=Path(filename).name,
+        filename=local_filename,
     )
 
 

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import sys
 import typing
+from pathlib import Path
 from dotenv import load_dotenv
 from mcp.types import ToolAnnotations
 from cartesia import Cartesia, RequestOptions, omit
@@ -28,14 +29,16 @@ from cartesia.types.voice_specifier_param import VoiceSpecifierParam
 from cartesia_mcp.custom_types import (
     DeletePronunciationDictResult,
     DeleteVoiceResult,
+    DownloadedFileResult,
     GeneratedAudioResult,
+    ListFilesResult,
     ListPronunciationDictsResult,
     ListVoicesResult,
     PronunciationDictItemParams,
 )
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
-from cartesia_mcp.extra_api import UsageInterval
+from cartesia_mcp.extra_api import DownloadFormat, FilePurpose, UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
 from cartesia_mcp.clients import admin_client, client, require_admin_client
 from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
@@ -46,6 +49,7 @@ from cartesia_mcp.utils import (
     create_output_file,
     cursor_page_to_result,
     iter_stt_audio_chunks,
+    save_downloaded_file,
     voice_list_page_to_result,
 )
 
@@ -748,6 +752,98 @@ def speech_to_text(
         sample_rate=sample_rate,
         timestamp_granularities=timestamp_granularities,
         request_options=request_options,
+    )
+
+
+@mcp.tool(
+    title="List cloud files",
+    annotations=_READ_ONLY,
+    description="""
+        List files stored in Cartesia cloud storage (`files.cartesia.ai`).
+
+        Use this to discover file IDs for TTS generations, voice samples, and other
+        uploaded assets before calling `download_file`.
+
+        Parameters
+        ----------
+        limit : typing.Optional[int]
+            Number of files per page (1–100).
+
+        purpose : typing.Optional[FilePurpose]
+            Filter by purpose, e.g. `tts_generation` for playground/API TTS outputs.
+
+        query : typing.Optional[str]
+            Search by filename.
+        """)
+def list_files(
+    limit: typing.Optional[int] = 10,
+    purpose: typing.Optional[FilePurpose] = None,
+    query: typing.Optional[str] = None,
+) -> ListFilesResult:
+    return typing.cast(
+        ListFilesResult,
+        extra_api.list_files(
+            client,
+            limit=limit,
+            purpose=purpose,
+            query=query,
+        ),
+    )
+
+
+@mcp.tool(
+    title="Get cloud file metadata",
+    annotations=_READ_ONLY,
+    description="""
+        Fetch metadata for a file in Cartesia cloud storage by ID.
+
+        Parameters
+        ----------
+        file_id : str
+            Cloud file ID (from TTS history, `list_files`, or API responses).
+        """)
+def get_file(file_id: str) -> dict[str, typing.Any]:
+    return extra_api.get_file_info(client, file_id)
+
+
+@mcp.tool(
+    title="Download cloud file",
+    annotations=_READ_ONLY,
+    description="""
+        Download a file from Cartesia cloud storage to the local output directory.
+
+        Use for TTS generations saved to cloud (`purpose=tts_generation`), voice
+        previews, and other files owned by the authenticated account.
+
+        Parameters
+        ----------
+        file_id : str
+            Cloud file ID to download.
+
+        format : typing.Optional[DownloadFormat]
+            Pass `playback` to wrap raw PCM TTS output as WAV for local playback.
+        """)
+def download_file(
+    file_id: str,
+    format: typing.Optional[DownloadFormat] = None,
+) -> DownloadedFileResult:
+    metadata = extra_api.get_file_info(client, file_id)
+    filename = metadata.get("filename")
+    if not isinstance(filename, str) or not filename.strip():
+        filename = file_id
+
+    content = extra_api.download_file_bytes(client, file_id, format=format)
+    output_path = save_downloaded_file(
+        OUTPUT_DIRECTORY,
+        file_id=file_id,
+        filename=filename,
+        content=content,
+    )
+
+    return DownloadedFileResult(
+        file_path=str(output_path),
+        file_id=file_id,
+        filename=Path(filename).name,
     )
 
 

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -89,6 +89,36 @@ def iter_stt_audio_chunks(
     )
 
 
+def save_downloaded_file(
+    output_directory: str,
+    *,
+    file_id: str,
+    filename: str,
+    content: bytes,
+) -> Path:
+    dir_path = Path(output_directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    if not os.access(dir_path, os.W_OK):
+        raise Exception(f"Output directory {dir_path} is not writable")
+
+    safe_name = Path(filename).name.strip() or file_id
+    if not Path(safe_name).suffix:
+        safe_name = f"{safe_name}.bin"
+
+    output_path = dir_path / f"download_{safe_name}"
+    if output_path.exists():
+        stem = Path(safe_name).stem
+        suffix = Path(safe_name).suffix
+        ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        output_path = dir_path / f"download_{stem}_{ts}{suffix}"
+
+    with output_path.open("wb") as f:
+        f.write(content)
+
+    return output_path
+
+
 def create_output_file(output_directory: str, tool_type: ToolType,
                        extension: OutputFormatContainer) -> Path:
     dir_path = Path(output_directory)

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -89,6 +89,19 @@ def iter_stt_audio_chunks(
     )
 
 
+def resolve_local_download_filename(
+    filename: str,
+    file_id: str,
+    *,
+    as_wav: bool = False,
+) -> str:
+    """Basename for a downloaded file on disk."""
+    safe_name = Path(filename).name.strip() or file_id
+    if as_wav:
+        return f"{Path(safe_name).stem}.wav"
+    return safe_name
+
+
 def save_downloaded_file(
     output_directory: str,
     *,

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -187,25 +187,10 @@ def main() -> int:
 
     files_result = run("list_files", lambda: s.list_files(limit=5))
     cloud_file_id: str | None = os.environ.get("CARTESIA_TEST_FILE_ID")
-    uploaded_file_id: str | None = None
     if files_result and not cloud_file_id:
         items = files_result.get("data", [])
         if items:
             cloud_file_id = items[0].get("id")
-
-    if tts_path and os.path.isfile(tts_path):
-        upload_result = run(
-            "upload_file",
-            lambda: s.upload_file(
-                file_path=tts_path,
-                purpose="original-audio-clip",
-            ),
-        )
-        if upload_result:
-            uploaded_file_id = upload_result.get("id")
-            if uploaded_file_id:
-                cloud_file_id = uploaded_file_id
-                ok("upload_file", f"id={uploaded_file_id}")
 
     if cloud_file_id:
         run("get_file", lambda: s.get_file(cloud_file_id))
@@ -218,12 +203,6 @@ def main() -> int:
                 failures.append("download_file(validation)")
     else:
         print("  SKIP get_file / download_file — no cloud files in account")
-
-    if uploaded_file_id:
-        run(
-            "delete_file",
-            lambda: s.delete_file(uploaded_file_id),
-        )
 
     dict_name = f"{TEST_DICT_NAME_PREFIX} {run_id}"
     create_dict = run(

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -185,6 +185,25 @@ def main() -> int:
     else:
         print("  SKIP get_credit_usage — set CARTESIA_ADMIN_API_KEY to test")
 
+    files_result = run("list_files", lambda: s.list_files(limit=5))
+    cloud_file_id: str | None = os.environ.get("CARTESIA_TEST_FILE_ID")
+    if files_result and not cloud_file_id:
+        items = files_result.get("data", [])
+        if items:
+            cloud_file_id = items[0].get("id")
+
+    if cloud_file_id:
+        run("get_file", lambda: s.get_file(cloud_file_id))
+        dl_result = run("download_file", lambda: s.download_file(cloud_file_id))
+        if dl_result is not None:
+            try:
+                assert_str_path(dl_result, "download_file")
+            except Exception as e:  # noqa: BLE001
+                fail("download_file validation", e)
+                failures.append("download_file(validation)")
+    else:
+        print("  SKIP get_file / download_file — no cloud files in account")
+
     dict_name = f"{TEST_DICT_NAME_PREFIX} {run_id}"
     create_dict = run(
         "create_pronunciation_dict",

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -187,10 +187,25 @@ def main() -> int:
 
     files_result = run("list_files", lambda: s.list_files(limit=5))
     cloud_file_id: str | None = os.environ.get("CARTESIA_TEST_FILE_ID")
+    uploaded_file_id: str | None = None
     if files_result and not cloud_file_id:
         items = files_result.get("data", [])
         if items:
             cloud_file_id = items[0].get("id")
+
+    if tts_path and os.path.isfile(tts_path):
+        upload_result = run(
+            "upload_file",
+            lambda: s.upload_file(
+                file_path=tts_path,
+                purpose="original-audio-clip",
+            ),
+        )
+        if upload_result:
+            uploaded_file_id = upload_result.get("id")
+            if uploaded_file_id:
+                cloud_file_id = uploaded_file_id
+                ok("upload_file", f"id={uploaded_file_id}")
 
     if cloud_file_id:
         run("get_file", lambda: s.get_file(cloud_file_id))
@@ -203,6 +218,12 @@ def main() -> int:
                 failures.append("download_file(validation)")
     else:
         print("  SKIP get_file / download_file — no cloud files in account")
+
+    if uploaded_file_id:
+        run(
+            "delete_file",
+            lambda: s.delete_file(uploaded_file_id),
+        )
 
     dict_name = f"{TEST_DICT_NAME_PREFIX} {run_id}"
     create_dict = run(

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -113,32 +113,3 @@ def test_save_downloaded_file_playback_pcm_saved_as_wav(tmp_path) -> None:
 
     assert output.suffix == ".wav"
     assert output.name == "download_generation.wav"
-
-
-@patch("cartesia_mcp.server.client")
-def test_upload_file_posts_multipart(mock_client: MagicMock, tmp_path) -> None:
-    mock_client.post.return_value = {"id": "file_new", "filename": "clip.wav"}
-    file_path = tmp_path / "clip.wav"
-    file_path.write_bytes(b"audio")
-
-    result = server.upload_file(str(file_path), purpose="original-audio-clip")
-
-    mock_client.post.assert_called_once()
-    args, kwargs = mock_client.post.call_args
-    assert args[0] == "https://files.cartesia.ai/files"
-    assert kwargs["body"] == {"purpose": "original-audio-clip"}
-    uploaded_name, _file_obj = kwargs["files"][0][1]
-    assert uploaded_name == "clip.wav"
-    assert result["id"] == "file_new"
-
-
-@patch("cartesia_mcp.server.client")
-def test_delete_file_calls_delete_endpoint(mock_client: MagicMock) -> None:
-    mock_client.delete.return_value = {"message": "File deleted successfully"}
-
-    result = server.delete_file("file_abc")
-
-    mock_client.delete.assert_called_once()
-    args, _kwargs = mock_client.delete.call_args
-    assert args[0] == "https://files.cartesia.ai/files/file_abc"
-    assert result == {"success": True}

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import cartesia_mcp.extra_api as extra_api
+import cartesia_mcp.server as server
+
+
+@patch("cartesia_mcp.server.client")
+def test_list_files_forwards_query_params(mock_client: MagicMock) -> None:
+    mock_client.get.return_value = {"data": [], "has_more": False}
+
+    server.list_files(limit=5, purpose="tts_generation", query="demo")
+
+    mock_client.get.assert_called_once()
+    args, kwargs = mock_client.get.call_args
+    assert args[0] == "https://files.cartesia.ai/files"
+    assert kwargs["options"] == {
+        "params": {"limit": "5", "purpose": "tts_generation", "q": "demo"},
+    }
+
+
+@patch("cartesia_mcp.server.client")
+def test_get_file_calls_info_endpoint(mock_client: MagicMock) -> None:
+    mock_client.get.return_value = {"id": "file_abc", "filename": "clip.wav"}
+
+    result = server.get_file("file_abc")
+
+    mock_client.get.assert_called_once()
+    args, _kwargs = mock_client.get.call_args
+    assert args[0] == "https://files.cartesia.ai/files/file_abc/info"
+    assert result["filename"] == "clip.wav"
+
+
+@patch("cartesia_mcp.server.save_downloaded_file")
+@patch("cartesia_mcp.server.extra_api.download_file_bytes")
+@patch("cartesia_mcp.server.extra_api.get_file_info")
+@patch("cartesia_mcp.server.client")
+def test_download_file_writes_to_output_directory(
+    mock_client: MagicMock,
+    mock_get_file_info: MagicMock,
+    mock_download_bytes: MagicMock,
+    mock_save: MagicMock,
+) -> None:
+    _ = mock_client
+    mock_get_file_info.return_value = {
+        "id": "file_abc",
+        "filename": "tts-output.pcm",
+    }
+    mock_download_bytes.return_value = b"audio-bytes"
+    mock_save.return_value = Path("/tmp/download_tts-output.pcm")
+
+    result = server.download_file("file_abc", format="playback")
+
+    mock_get_file_info.assert_called_once_with(mock_client, "file_abc")
+    mock_download_bytes.assert_called_once_with(
+        mock_client,
+        "file_abc",
+        format="playback",
+    )
+    mock_save.assert_called_once_with(
+        server.OUTPUT_DIRECTORY,
+        file_id="file_abc",
+        filename="tts-output.pcm",
+        content=b"audio-bytes",
+    )
+    assert result == {
+        "file_path": "/tmp/download_tts-output.pcm",
+        "file_id": "file_abc",
+        "filename": "tts-output.pcm",
+    }
+
+
+def test_files_base_url_defaults_to_prod() -> None:
+    assert extra_api.files_base_url() == "https://files.cartesia.ai"
+
+
+def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:
+    from cartesia_mcp.utils import save_downloaded_file
+
+    output = save_downloaded_file(
+        str(tmp_path),
+        file_id="file_abc",
+        filename="../evil/name.wav",
+        content=b"data",
+    )
+
+    assert output.parent == tmp_path
+    assert output.name == "download_name.wav"
+    assert output.read_bytes() == b"data"

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -1,33 +1,46 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import cartesia_mcp.extra_api as extra_api
 import cartesia_mcp.server as server
 
 
+@pytest.fixture
+def prod_files_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARTESIA_FILES_BASE_URL", raising=False)
+
+
 @patch("cartesia_mcp.server.client")
-def test_list_files_forwards_query_params(mock_client: MagicMock) -> None:
+def test_list_files_forwards_query_params(
+    mock_client: MagicMock,
+    prod_files_base_url: None,
+) -> None:
     mock_client.get.return_value = {"data": [], "has_more": False}
 
     server.list_files(limit=5, purpose="tts_generation", query="demo")
 
     mock_client.get.assert_called_once()
     args, kwargs = mock_client.get.call_args
-    assert args[0] == "https://files.cartesia.ai/files"
+    assert args[0] == extra_api._files_url("/files")
     assert kwargs["options"] == {
         "params": {"limit": "5", "purpose": "tts_generation", "q": "demo"},
     }
 
 
 @patch("cartesia_mcp.server.client")
-def test_get_file_calls_info_endpoint(mock_client: MagicMock) -> None:
+def test_get_file_calls_info_endpoint(
+    mock_client: MagicMock,
+    prod_files_base_url: None,
+) -> None:
     mock_client.get.return_value = {"id": "file_abc", "filename": "clip.wav"}
 
     result = server.get_file("file_abc")
 
     mock_client.get.assert_called_once()
     args, _kwargs = mock_client.get.call_args
-    assert args[0] == "https://files.cartesia.ai/files/file_abc/info"
+    assert args[0] == extra_api._files_url("/files/file_abc/info")
     assert result["filename"] == "clip.wav"
 
 
@@ -70,8 +83,14 @@ def test_download_file_writes_to_output_directory(
     }
 
 
-def test_files_base_url_defaults_to_prod() -> None:
-    assert extra_api.files_base_url() == "https://files.cartesia.ai"
+def test_files_base_url_defaults_to_prod(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARTESIA_FILES_BASE_URL", raising=False)
+    assert extra_api.files_base_url() == extra_api.DEFAULT_FILES_BASE_URL
+
+
+def test_files_base_url_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARTESIA_FILES_BASE_URL", "https://files.staging.example")
+    assert extra_api.files_base_url() == "https://files.staging.example"
 
 
 def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -87,3 +87,32 @@ def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:
     assert output.parent == tmp_path
     assert output.name == "download_name.wav"
     assert output.read_bytes() == b"data"
+
+
+@patch("cartesia_mcp.server.client")
+def test_upload_file_posts_multipart(mock_client: MagicMock, tmp_path) -> None:
+    mock_client.post.return_value = {"id": "file_new", "filename": "clip.wav"}
+    file_path = tmp_path / "clip.wav"
+    file_path.write_bytes(b"audio")
+
+    result = server.upload_file(str(file_path), purpose="original-audio-clip")
+
+    mock_client.post.assert_called_once()
+    args, kwargs = mock_client.post.call_args
+    assert args[0] == "https://files.cartesia.ai/files"
+    assert kwargs["body"] == {"purpose": "original-audio-clip"}
+    uploaded_name, _file_obj = kwargs["files"][0][1]
+    assert uploaded_name == "clip.wav"
+    assert result["id"] == "file_new"
+
+
+@patch("cartesia_mcp.server.client")
+def test_delete_file_calls_delete_endpoint(mock_client: MagicMock) -> None:
+    mock_client.delete.return_value = {"message": "File deleted successfully"}
+
+    result = server.delete_file("file_abc")
+
+    mock_client.delete.assert_called_once()
+    args, _kwargs = mock_client.delete.call_args
+    assert args[0] == "https://files.cartesia.ai/files/file_abc"
+    assert result == {"success": True}

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -47,7 +47,7 @@ def test_download_file_writes_to_output_directory(
         "filename": "tts-output.pcm",
     }
     mock_download_bytes.return_value = b"audio-bytes"
-    mock_save.return_value = Path("/tmp/download_tts-output.pcm")
+    mock_save.return_value = Path("/tmp/download_tts-output.wav")
 
     result = server.download_file("file_abc", format="playback")
 
@@ -60,13 +60,13 @@ def test_download_file_writes_to_output_directory(
     mock_save.assert_called_once_with(
         server.OUTPUT_DIRECTORY,
         file_id="file_abc",
-        filename="tts-output.pcm",
+        filename="tts-output.wav",
         content=b"audio-bytes",
     )
     assert result == {
-        "file_path": "/tmp/download_tts-output.pcm",
+        "file_path": "/tmp/download_tts-output.wav",
         "file_id": "file_abc",
-        "filename": "tts-output.pcm",
+        "filename": "tts-output.wav",
     }
 
 
@@ -87,6 +87,32 @@ def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:
     assert output.parent == tmp_path
     assert output.name == "download_name.wav"
     assert output.read_bytes() == b"data"
+
+
+def test_resolve_local_download_filename_playback_uses_wav() -> None:
+    from cartesia_mcp.utils import resolve_local_download_filename
+
+    assert resolve_local_download_filename("tts-output.pcm", "file_abc") == "tts-output.pcm"
+    assert (
+        resolve_local_download_filename("tts-output.pcm", "file_abc", as_wav=True)
+        == "tts-output.wav"
+    )
+    assert resolve_local_download_filename("noext", "file_abc", as_wav=True) == "noext.wav"
+
+
+def test_save_downloaded_file_playback_pcm_saved_as_wav(tmp_path) -> None:
+    from cartesia_mcp.utils import resolve_local_download_filename, save_downloaded_file
+
+    local_name = resolve_local_download_filename("generation.pcm", "file_abc", as_wav=True)
+    output = save_downloaded_file(
+        str(tmp_path),
+        file_id="file_abc",
+        filename=local_name,
+        content=b"RIFF....WAVE",
+    )
+
+    assert output.suffix == ".wav"
+    assert output.name == "download_generation.wav"
 
 
 @patch("cartesia_mcp.server.client")

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -7,7 +7,7 @@ import cartesia_mcp.server as server
 
 def test_all_tools_have_title_and_hint():
     tools = server.mcp._tool_manager.list_tools()
-    assert len(tools) == 15
+    assert len(tools) == 18
 
     for tool in tools:
         assert tool.title, f"{tool.name} is missing title"
@@ -19,7 +19,10 @@ def test_all_tools_have_title_and_hint():
 
 def test_read_only_tools():
     read_only = {
+        "download_file",
+        "get_file",
         "get_voice",
+        "list_files",
         "list_voices",
         "speech_to_text",
         "get_credit_usage",

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -7,7 +7,7 @@ import cartesia_mcp.server as server
 
 def test_all_tools_have_title_and_hint():
     tools = server.mcp._tool_manager.list_tools()
-    assert len(tools) == 20
+    assert len(tools) == 18
 
     for tool in tools:
         assert tool.title, f"{tool.name} is missing title"
@@ -46,8 +46,6 @@ def test_write_tools():
         "create_pronunciation_dict",
         "update_pronunciation_dict",
         "delete_pronunciation_dict",
-        "upload_file",
-        "delete_file",
     }
     tools = {tool.name: tool for tool in server.mcp._tool_manager.list_tools()}
     for name in write_tools:

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -7,7 +7,7 @@ import cartesia_mcp.server as server
 
 def test_all_tools_have_title_and_hint():
     tools = server.mcp._tool_manager.list_tools()
-    assert len(tools) == 18
+    assert len(tools) == 20
 
     for tool in tools:
         assert tool.title, f"{tool.name} is missing title"
@@ -46,6 +46,8 @@ def test_write_tools():
         "create_pronunciation_dict",
         "update_pronunciation_dict",
         "delete_pronunciation_dict",
+        "upload_file",
+        "delete_file",
     }
     tools = {tool.name: tool for tool in server.mcp._tool_manager.list_tools()}
     for name in write_tools:

--- a/tests/test_tool_visibility.py
+++ b/tests/test_tool_visibility.py
@@ -42,7 +42,7 @@ def test_list_tools_hides_admin_tools_without_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 17
+    assert len(names) == 19
     assert "get_credit_usage" not in names
 
 
@@ -53,5 +53,5 @@ def test_list_tools_shows_admin_tools_with_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 18
+    assert len(names) == 20
     assert "get_credit_usage" in names

--- a/tests/test_tool_visibility.py
+++ b/tests/test_tool_visibility.py
@@ -42,7 +42,7 @@ def test_list_tools_hides_admin_tools_without_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 19
+    assert len(names) == 17
     assert "get_credit_usage" not in names
 
 
@@ -53,5 +53,5 @@ def test_list_tools_shows_admin_tools_with_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 20
+    assert len(names) == 18
     assert "get_credit_usage" in names

--- a/tests/test_tool_visibility.py
+++ b/tests/test_tool_visibility.py
@@ -42,7 +42,7 @@ def test_list_tools_hides_admin_tools_without_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 14
+    assert len(names) == 17
     assert "get_credit_usage" not in names
 
 
@@ -53,5 +53,5 @@ def test_list_tools_shows_admin_tools_with_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 15
+    assert len(names) == 18
     assert "get_credit_usage" in names


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/PSE-19/add-mcp-support-for-files-api

## Summary

Adds read-only MCP tools for the Cartesia files API (`files.cartesia.ai`). The Python SDK does not generate a files client, so these call the HTTP API directly via `extra_api.py` (same pattern as `get_credit_usage`).

The scope is cloud assets Cartesia already stores for the org — especially playground/API TTS history (`tts_generation`) — not a generic file server. Agents generate audio locally via `text_to_speech` / `voice_change`, then use these tools to discover and pull prior cloud generations when needed.

## Changes

- `list_files` — `GET /files` (filter by purpose, search by filename)
- `get_file` — `GET /files/{id}/info`
- `download_file` — `GET /files/{id}/download` → local `OUTPUT_DIRECTORY` (optional `format=playback` for PCM→WAV)
- `extra_api.py` helpers + path sanitization for downloads
- Unit tests and smoke-test coverage for list/get/download

Intentionally excluded: `upload_file`, `delete_file`, and `PUT /files/{id}` — MCP should not be a generic files CRUD surface.

## Test plan

- [x] `uv run pytest`
- [ ] `uv run python scripts/test_all_tools.py` (needs account with cloud files or `CARTESIA_TEST_FILE_ID`)
- [ ] Hosted MCP: `list_files` → `download_file` on a known `tts_generation` file ID

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API access and local file writes with path sanitization; no auth or destructive file operations added.
> 
> **Overview**
> Adds **read-only MCP tools** for org cloud files on `files.cartesia.ai` (HTTP via `extra_api.py`, same pattern as credit usage), since the Python SDK has no files client.
> 
> Agents can **`list_files`** (purpose/filename filters), **`get_file`** for metadata, and **`download_file`** into `OUTPUT_DIRECTORY`, with optional **`format=playback`** (PCM saved locally as `.wav`). Downloads use basename sanitization and `download_*` naming with collision timestamps. Base URL is configurable via **`CARTESIA_FILES_BASE_URL`**.
> 
> README documents the new tools; unit tests cover HTTP wiring and save helpers; the all-tools smoke script exercises list/get/download when cloud files or `CARTESIA_TEST_FILE_ID` exist. Upload/delete/update file endpoints are intentionally out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce39a8a664481eb8dfab44624a214b3e0be4ab72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->