### PR TITLE
feat: persist TTS to cloud and return download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Ask your agent things like:
 
 | Tool | Description |
 |------|-------------|
-| `text_to_speech` | Convert text to audio; optional speed, volume, emotion, and pronunciation dict |
+| `text_to_speech` | Convert text to audio; optional speed, volume, emotion, and pronunciation dict. Default `save=true` returns `file_id` and a 24h `download_url`. |
 | `speech_to_text` | Transcribe an audio file (`mode=batch` default, or `mode=stream`) |
 | `list_voices` | List available voices (filter by language, search, gender, etc.) |
 | `get_voice` | Fetch metadata for a voice by ID |
@@ -71,9 +71,7 @@ Ask your agent things like:
 | `get_pronunciation_dict` | Get a pronunciation dictionary by ID |
 | `update_pronunciation_dict` | Update a pronunciation dictionary |
 | `delete_pronunciation_dict` | Delete a pronunciation dictionary |
-| `list_files` | List Cartesia cloud-stored files (e.g. `tts_generation` history) |
-| `get_file` | Get cloud file metadata (`GET /files/{id}/info`) |
-| `download_file` | Download a cloud-stored file to the local output directory |
+| `download_file` | Fetch a cloud file by ID (`download_url` + local copy) |
 | `get_credit_usage` | Credit usage over time (`CARTESIA_ADMIN_API_KEY`) |
 
 See [`cartesia_mcp/server.py`](./cartesia_mcp/server.py) for parameters and return types.

--- a/cartesia_mcp/custom_types/__init__.py
+++ b/cartesia_mcp/custom_types/__init__.py
@@ -7,7 +7,6 @@ from .tool_results import (
     DownloadedFileResult,
     GeneratedAudioResult,
     DeleteVoiceResult,
-    ListFilesResult,
     ListVoicesResult,
 )
 from .tool_type import ToolType
@@ -17,7 +16,6 @@ __all__ = [
     "DownloadedFileResult",
     "GeneratedAudioResult",
     "DeleteVoiceResult",
-    "ListFilesResult",
     "ListPronunciationDictsResult",
     "ListVoicesResult",
     "PronunciationDictItemParams",

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -5,24 +5,22 @@ class DeleteVoiceResult(typing.TypedDict):
     success: bool
 
 
-class GeneratedAudioResult(typing.TypedDict):
+class GeneratedAudioResult(typing.TypedDict, total=False):
+    """TTS with save=true returns file_id and download_url; voice_change is local-only."""
+
+    file_id: str
+    download_url: str
     file_path: str
 
 
 class DownloadedFileResult(typing.TypedDict):
-    file_path: str
     file_id: str
+    download_url: str
+    file_path: str
     filename: str
-
-
-class ListFilesResult(typing.TypedDict, total=False):
-    data: typing.List[typing.Any]
-    has_more: bool
 
 
 class ListVoicesResult(typing.TypedDict, total=False):
     data: typing.List[typing.Any]
     has_more: bool
     next_page: str
-
-

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -6,18 +6,18 @@ class DeleteVoiceResult(typing.TypedDict):
 
 
 class GeneratedAudioResult(typing.TypedDict, total=False):
-    """TTS with save=true returns file_id and download_url; voice_change is local-only."""
+    """TTS with save=true returns file_id and usually download_url; voice_change is local-only."""
 
     file_id: str
     download_url: str
     file_path: str
 
 
-class DownloadedFileResult(typing.TypedDict):
+class DownloadedFileResult(typing.TypedDict, total=False):
     file_id: str
-    download_url: str
     file_path: str
     filename: str
+    download_url: str
 
 
 class ListVoicesResult(typing.TypedDict, total=False):

--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -4,13 +4,14 @@ HTTP helpers for Cartesia endpoints not generated on the Python SDK.
 `get_usage_credits` must be called with a client authenticated using an admin API key
 (`CARTESIA_ADMIN_API_KEY`); standard API keys are rejected on `/usage/*`.
 
-Files helpers call `files.cartesia.ai` (override with `CARTESIA_FILES_BASE_URL`).
+Files helpers call the Cartesia files service (override with `CARTESIA_FILES_BASE_URL`).
 """
 
 from __future__ import annotations
 
 import os
 import typing
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from cartesia import Cartesia
 
@@ -18,19 +19,10 @@ from cartesia_mcp.config import env_or_none
 
 UsageInterval = typing.Literal["day", "week", "month"]
 DownloadFormat = typing.Literal["playback"]
-FilePurpose = typing.Literal[
-    "agent_background_sound",
-    "agent_source_archive",
-    "fine_tune",
-    "narration_export",
-    "original-audio-clip",
-    "synthetic-conditioning-audio",
-    "tts_generation",
-    "voice-clone",
-    "voice_sample",
-]
 
 DEFAULT_FILES_BASE_URL = "https://files.cartesia.ai"
+DEFAULT_DOWNLOAD_LINK_LIFETIME_HOURS = 24
+CARTESIA_FILE_ID_HEADER = "cartesia-file-id"
 
 
 def files_base_url() -> str:
@@ -39,6 +31,23 @@ def files_base_url() -> str:
 
 def _files_url(path: str) -> str:
     return f"{files_base_url().rstrip('/')}{path}"
+
+
+def file_id_from_response_headers(headers: typing.Mapping[str, str]) -> typing.Optional[str]:
+    for key, value in headers.items():
+        if key.lower() == CARTESIA_FILE_ID_HEADER:
+            stripped = value.strip()
+            return stripped or None
+    return None
+
+
+def with_download_format(url: str, format: typing.Optional[DownloadFormat]) -> str:
+    if format is None:
+        return url
+    parsed = urlparse(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["format"] = format
+    return urlunparse(parsed._replace(query=urlencode(query)))
 
 
 def get_usage_credits(
@@ -88,22 +97,18 @@ def download_file_bytes(
     )
 
 
-def list_files(
+def create_file_download_link(
     client: Cartesia,
+    file_id: str,
     *,
-    limit: typing.Optional[int] = None,
-    purpose: typing.Optional[FilePurpose] = None,
-    query: typing.Optional[str] = None,
-) -> dict[str, typing.Any]:
-    params: dict[str, str] = {}
-    if limit is not None:
-        params["limit"] = str(limit)
-    if purpose is not None:
-        params["purpose"] = purpose
-    if query is not None:
-        params["q"] = query
-    return client.get(
-        _files_url("/files"),
+    lifetime_hours: int = DEFAULT_DOWNLOAD_LINK_LIFETIME_HOURS,
+) -> str:
+    payload = client.post(
+        _files_url("/links"),
         cast_to=dict[str, typing.Any],
-        options={"params": params} if params else None,
+        body={"file_id": file_id, "lifetime": f"{lifetime_hours}h"},
     )
+    url = payload.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise RuntimeError("files API did not return a download link URL")
+    return url

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -31,14 +31,13 @@ from cartesia_mcp.custom_types import (
     DeleteVoiceResult,
     DownloadedFileResult,
     GeneratedAudioResult,
-    ListFilesResult,
     ListPronunciationDictsResult,
     ListVoicesResult,
     PronunciationDictItemParams,
 )
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
-from cartesia_mcp.extra_api import DownloadFormat, FilePurpose, UsageInterval
+from cartesia_mcp.extra_api import DownloadFormat, UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
 from cartesia_mcp.clients import admin_client, client, require_admin_client
 from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
@@ -141,10 +140,65 @@ def _stream_stt_uses_manual_finalize(
     return language is not None and language != "en"
 
 
+def _write_audio_output(
+    audio_bytes: bytes,
+    tool_type: typing.Literal["text_to_speech", "voice_change"],
+    extension: OutputFormatContainer,
+) -> str:
+    output_file = create_output_file(OUTPUT_DIRECTORY, tool_type, extension)
+    with output_file.open("wb") as f:
+        f.write(audio_bytes)
+    return str(output_file)
+
+
+def _cloud_download_url(
+    file_id: str,
+    *,
+    format: typing.Optional[DownloadFormat] = None,
+) -> str:
+    link_url = extra_api.create_file_download_link(client, file_id)
+    return extra_api.with_download_format(link_url, format)
+
+
+def _deliver_cloud_file(
+    file_id: str,
+    *,
+    format: typing.Optional[DownloadFormat] = None,
+) -> DownloadedFileResult:
+    metadata = extra_api.get_file_info(client, file_id)
+    filename = metadata.get("filename")
+    if not isinstance(filename, str) or not filename.strip():
+        filename = file_id
+
+    local_filename = resolve_local_download_filename(
+        filename,
+        file_id,
+        as_wav=format == "playback",
+    )
+    content = extra_api.download_file_bytes(client, file_id, format=format)
+    output_path = save_downloaded_file(
+        OUTPUT_DIRECTORY,
+        file_id=file_id,
+        filename=local_filename,
+        content=content,
+    )
+    return DownloadedFileResult(
+        file_id=file_id,
+        download_url=_cloud_download_url(file_id, format=format),
+        file_path=str(output_path),
+        filename=local_filename,
+    )
+
+
 @mcp.tool(
     title="Convert text to speech",
     annotations=_WRITE,
     description="""
+        Generate speech audio from text. By default (`save=true`) the audio is persisted
+        in Cartesia cloud storage and the response includes `file_id` and `download_url`
+        (24-hour public link). `file_path` is a local copy for same-machine tools like
+        `speech_to_text` when running MCP locally.
+
         Parameters
         ----------
         transcript : str
@@ -174,6 +228,11 @@ def _stream_stt_uses_manual_finalize(
         pronunciation_dict_id : typing.Optional[str]
             Pronunciation dictionary ID to apply for this generation only.
 
+        save : bool
+            When true (default), persist the generation to cloud storage and return `file_id`
+            plus `download_url`. Pass `download_file` with that `file_id` to refresh the link
+            or write another local copy.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration (timeout, headers, query params, extra body fields).
 
@@ -189,6 +248,7 @@ def text_to_speech(
     volume: typing.Optional[float] = None,
     emotion: typing.Optional[str] = None,
     pronunciation_dict_id: typing.Optional[str] = None,
+    save: bool = True,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> GeneratedAudioResult:
     generation_config = _build_generation_config(
@@ -209,16 +269,31 @@ def text_to_speech(
         tts_kwargs["generation_config"] = generation_config
     if duration is not None:
         _merge_extra_body(tts_kwargs, {"duration": duration})
+    if save:
+        tts_kwargs["save"] = True
     result = client.tts.generate(**tts_kwargs)
 
-    output_file = create_output_file(OUTPUT_DIRECTORY, "text_to_speech",
-                                        output_format["container"])
-
     audio_bytes = result.read()
-    with output_file.open("wb") as f:
-        f.write(audio_bytes)
+    file_path = _write_audio_output(
+        audio_bytes,
+        "text_to_speech",
+        output_format["container"],
+    )
 
-    return GeneratedAudioResult(file_path=str(output_file))
+    if not save:
+        return GeneratedAudioResult(file_path=file_path)
+
+    file_id = extra_api.file_id_from_response_headers(result.headers)
+    if not file_id:
+        raise RuntimeError(
+            "TTS save was requested but the API did not return Cartesia-File-ID",
+        )
+
+    return GeneratedAudioResult(
+        file_id=file_id,
+        download_url=_cloud_download_url(file_id),
+        file_path=file_path,
+    )
 
 
 @mcp.tool(
@@ -269,12 +344,13 @@ def voice_change(
         )
         audio_bytes = result.read()
 
-    output_file = create_output_file(OUTPUT_DIRECTORY, "voice_change",
-                                        output_format_container)
-    with output_file.open("wb") as f:
-        f.write(audio_bytes)
+    file_path = _write_audio_output(
+        audio_bytes,
+        "voice_change",
+        output_format_container,
+    )
 
-    return GeneratedAudioResult(file_path=str(output_file))
+    return GeneratedAudioResult(file_path=file_path)
 
 @mcp.tool(
     title="Localize voice",
@@ -757,103 +833,29 @@ def speech_to_text(
 
 
 @mcp.tool(
-    title="List files",
-    annotations=_READ_ONLY,
-    description="""
-        List files stored by Cartesia for your org (`GET /files` on `files.cartesia.ai`).
-
-        Use to discover cloud-stored generations (e.g. playground TTS history with
-        `purpose=tts_generation`) before calling `download_file`. This is not a
-        generic upload target — use `text_to_speech` / `voice_change` to generate audio.
-
-        Parameters
-        ----------
-        limit : typing.Optional[int]
-            Number of files per page (1–100).
-
-        purpose : typing.Optional[FilePurpose]
-            Filter by purpose (e.g. `tts_generation`, `voice-clone`, `voice_sample`).
-
-        query : typing.Optional[str]
-            Search by filename.
-        """)
-def list_files(
-    limit: typing.Optional[int] = 10,
-    purpose: typing.Optional[FilePurpose] = None,
-    query: typing.Optional[str] = None,
-) -> ListFilesResult:
-    return typing.cast(
-        ListFilesResult,
-        extra_api.list_files(
-            client,
-            limit=limit,
-            purpose=purpose,
-            query=query,
-        ),
-    )
-
-
-@mcp.tool(
-    title="Get file metadata",
-    annotations=_READ_ONLY,
-    description="""
-        Fetch file metadata (`GET /files/{id}/info` on `files.cartesia.ai`).
-
-        Parameters
-        ----------
-        file_id : str
-            File ID.
-        """)
-def get_file(file_id: str) -> dict[str, typing.Any]:
-    return extra_api.get_file_info(client, file_id)
-
-
-@mcp.tool(
     title="Download file",
     annotations=_READ_ONLY,
     description="""
-        Download a Cartesia cloud-stored file to the local output directory
-        (`GET /files/{id}/download` on `files.cartesia.ai`).
+        Fetch a Cartesia cloud-stored file by ID. Returns a 24-hour `download_url` for
+        hosted and remote clients, and writes a local copy to `OUTPUT_DIRECTORY` for
+        same-machine tools like `speech_to_text`.
 
-        Typical use: pull a `tts_generation` or other org-owned asset for local
-        playback or `speech_to_text`.
+        Use the `file_id` from a prior `text_to_speech` call (`save=true`, the default)
+        or from playground TTS history.
 
         Parameters
         ----------
         file_id : str
-            File ID to download.
+            Cloud file ID (e.g. from `text_to_speech`).
 
         format : typing.Optional[DownloadFormat]
-            Pass `playback` to wrap raw PCM as WAV for local playback.
+            Pass `playback` to wrap raw PCM as WAV in the download link and local file.
         """)
 def download_file(
     file_id: str,
     format: typing.Optional[DownloadFormat] = None,
 ) -> DownloadedFileResult:
-    metadata = extra_api.get_file_info(client, file_id)
-    filename = metadata.get("filename")
-    if not isinstance(filename, str) or not filename.strip():
-        filename = file_id
-
-    local_filename = resolve_local_download_filename(
-        filename,
-        file_id,
-        as_wav=format == "playback",
-    )
-
-    content = extra_api.download_file_bytes(client, file_id, format=format)
-    output_path = save_downloaded_file(
-        OUTPUT_DIRECTORY,
-        file_id=file_id,
-        filename=local_filename,
-        content=content,
-    )
-
-    return DownloadedFileResult(
-        file_path=str(output_path),
-        file_id=file_id,
-        filename=local_filename,
-    )
+    return _deliver_cloud_file(file_id, format=format)
 
 
 @mcp.tool(

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -151,13 +151,16 @@ def _write_audio_output(
     return str(output_file)
 
 
-def _cloud_download_url(
+def _try_cloud_download_url(
     file_id: str,
     *,
     format: typing.Optional[DownloadFormat] = None,
-) -> str:
-    link_url = extra_api.create_file_download_link(client, file_id)
-    return extra_api.with_download_format(link_url, format)
+) -> typing.Optional[str]:
+    try:
+        link_url = extra_api.create_file_download_link(client, file_id)
+        return extra_api.with_download_format(link_url, format)
+    except Exception:
+        return None
 
 
 def _deliver_cloud_file(
@@ -182,12 +185,15 @@ def _deliver_cloud_file(
         filename=local_filename,
         content=content,
     )
-    return DownloadedFileResult(
-        file_id=file_id,
-        download_url=_cloud_download_url(file_id, format=format),
-        file_path=str(output_path),
-        filename=local_filename,
-    )
+    delivered: DownloadedFileResult = {
+        "file_id": file_id,
+        "file_path": str(output_path),
+        "filename": local_filename,
+    }
+    download_url = _try_cloud_download_url(file_id, format=format)
+    if download_url is not None:
+        delivered["download_url"] = download_url
+    return delivered
 
 
 @mcp.tool(
@@ -289,11 +295,14 @@ def text_to_speech(
             "TTS save was requested but the API did not return Cartesia-File-ID",
         )
 
-    return GeneratedAudioResult(
-        file_id=file_id,
-        download_url=_cloud_download_url(file_id),
-        file_path=file_path,
-    )
+    saved: GeneratedAudioResult = {
+        "file_id": file_id,
+        "file_path": file_path,
+    }
+    download_url = _try_cloud_download_url(file_id)
+    if download_url is not None:
+        saved["download_url"] = download_url
+    return saved
 
 
 @mcp.tool(

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -112,6 +112,14 @@ def _merge_extra_body(
         sdk_kwargs["extra_body"] = extra_fields
 
 
+def _apply_tts_save_flag(tts_kwargs: dict[str, typing.Any], save: bool) -> None:
+    """Tool `save` wins over `save` in request_options extra_body / extra_json."""
+    extra_body = tts_kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        extra_body.pop("save", None)
+    tts_kwargs["save"] = save
+
+
 def _stt_words_from_timestamps(
     word_timestamp_groups: typing.Optional[typing.Sequence[WordTimestamps]],
 ) -> typing.Optional[typing.List[SttWord]]:
@@ -277,8 +285,7 @@ def text_to_speech(
         tts_kwargs["generation_config"] = generation_config
     if duration is not None:
         _merge_extra_body(tts_kwargs, {"duration": duration})
-    if save:
-        tts_kwargs["save"] = True
+    _apply_tts_save_flag(tts_kwargs, save)
     result = client.tts.generate(**tts_kwargs)
 
     audio_bytes = result.read()

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -151,11 +151,12 @@ def _write_audio_output(
     return str(output_file)
 
 
-def _try_cloud_download_url(
+def _try_create_download_link(
     file_id: str,
     *,
     format: typing.Optional[DownloadFormat] = None,
 ) -> typing.Optional[str]:
+    """Mint a time-limited public download link; None if POST /links fails."""
     try:
         link_url = extra_api.create_file_download_link(client, file_id)
         return extra_api.with_download_format(link_url, format)
@@ -190,7 +191,7 @@ def _deliver_cloud_file(
         "file_path": str(output_path),
         "filename": local_filename,
     }
-    download_url = _try_cloud_download_url(file_id, format=format)
+    download_url = _try_create_download_link(file_id, format=format)
     if download_url is not None:
         delivered["download_url"] = download_url
     return delivered
@@ -202,8 +203,9 @@ def _deliver_cloud_file(
     description="""
         Generate speech audio from text. By default (`save=true`) the audio is persisted
         in Cartesia cloud storage and the response includes `file_id` and `download_url`
-        (24-hour public link). `file_path` is a local copy for same-machine tools like
-        `speech_to_text` when running MCP locally.
+        (24-hour public link). Hosted clients (Claude, ChatGPT) should use `download_url`.
+        `file_path` is a copy on the MCP server host — useful for local `uvx` and for
+        server-side tools like `speech_to_text` in the same MCP session.
 
         Parameters
         ----------
@@ -299,7 +301,7 @@ def text_to_speech(
         "file_id": file_id,
         "file_path": file_path,
     }
-    download_url = _try_cloud_download_url(file_id)
+    download_url = _try_create_download_link(file_id)
     if download_url is not None:
         saved["download_url"] = download_url
     return saved
@@ -846,8 +848,8 @@ def speech_to_text(
     annotations=_READ_ONLY,
     description="""
         Fetch a Cartesia cloud-stored file by ID. Returns a 24-hour `download_url` for
-        hosted and remote clients, and writes a local copy to `OUTPUT_DIRECTORY` for
-        same-machine tools like `speech_to_text`.
+        hosted and remote clients. Also writes a copy to `OUTPUT_DIRECTORY` on the MCP
+        server host (for local `uvx` or server-side `speech_to_text` in the same session).
 
         Use the `file_id` from a prior `text_to_speech` call (`save=true`, the default)
         or from playground TTS history.

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -115,8 +115,12 @@ def _merge_extra_body(
 def _apply_tts_save_flag(tts_kwargs: dict[str, typing.Any], save: bool) -> None:
     """Tool `save` wins over `save` in request_options extra_body / extra_json."""
     extra_body = tts_kwargs.get("extra_body")
-    if isinstance(extra_body, dict):
-        extra_body.pop("save", None)
+    if isinstance(extra_body, dict) and "save" in extra_body:
+        stripped = {key: value for key, value in extra_body.items() if key != "save"}
+        if stripped:
+            tts_kwargs["extra_body"] = stripped
+        else:
+            tts_kwargs.pop("extra_body", None)
     tts_kwargs["save"] = save
 
 

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -147,9 +147,19 @@ def main() -> int:
         try:
             tts_path = assert_str_path(tts_result, "text_to_speech")
             ok("text_to_speech output", tts_path)
+            file_id = tts_result.get("file_id")
+            download_url = tts_result.get("download_url")
+            if not file_id or not download_url:
+                failures.append("text_to_speech(cloud)")
+                print("  FAIL text_to_speech: missing file_id or download_url (save=true)")
+            else:
+                ok("text_to_speech cloud", f"file_id={file_id}")
         except Exception as e:  # noqa: BLE001
             fail("text_to_speech validation", e)
             failures.append("text_to_speech(validation)")
+            file_id = None
+    else:
+        file_id = None
 
     if tts_path and os.path.isfile(tts_path):
         stt_result = run(
@@ -185,24 +195,22 @@ def main() -> int:
     else:
         print("  SKIP get_credit_usage — set CARTESIA_ADMIN_API_KEY to test")
 
-    files_result = run("list_files", lambda: s.list_files(limit=5))
-    cloud_file_id: str | None = os.environ.get("CARTESIA_TEST_FILE_ID")
-    if files_result and not cloud_file_id:
-        items = files_result.get("data", [])
-        if items:
-            cloud_file_id = items[0].get("id")
+    cloud_file_id: str | None = os.environ.get("CARTESIA_TEST_FILE_ID") or (
+        tts_result.get("file_id") if isinstance(tts_result, dict) else None
+    )
 
     if cloud_file_id:
-        run("get_file", lambda: s.get_file(cloud_file_id))
         dl_result = run("download_file", lambda: s.download_file(cloud_file_id))
         if dl_result is not None:
             try:
                 assert_str_path(dl_result, "download_file")
+                if not dl_result.get("download_url"):
+                    raise ValueError("download_file: missing download_url")
             except Exception as e:  # noqa: BLE001
                 fail("download_file validation", e)
                 failures.append("download_file(validation)")
     else:
-        print("  SKIP get_file / download_file — no cloud files in account")
+        print("  SKIP download_file — no file_id from text_to_speech or CARTESIA_TEST_FILE_ID")
 
     dict_name = f"{TEST_DICT_NAME_PREFIX} {run_id}"
     create_dict = run(

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -149,11 +149,14 @@ def main() -> int:
             ok("text_to_speech output", tts_path)
             file_id = tts_result.get("file_id")
             download_url = tts_result.get("download_url")
-            if not file_id or not download_url:
+            if not file_id:
                 failures.append("text_to_speech(cloud)")
-                print("  FAIL text_to_speech: missing file_id or download_url (save=true)")
+                print("  FAIL text_to_speech: missing file_id (save=true)")
+            elif download_url:
+                ok("text_to_speech cloud", f"file_id={file_id}")
             else:
                 ok("text_to_speech cloud", f"file_id={file_id}")
+                print("  WARN text_to_speech: download_url omitted (link minting failed)")
         except Exception as e:  # noqa: BLE001
             fail("text_to_speech validation", e)
             failures.append("text_to_speech(validation)")
@@ -205,7 +208,7 @@ def main() -> int:
             try:
                 assert_str_path(dl_result, "download_file")
                 if not dl_result.get("download_url"):
-                    raise ValueError("download_file: missing download_url")
+                    print("  WARN download_file: download_url omitted (link minting failed)")
             except Exception as e:  # noqa: BLE001
                 fail("download_file validation", e)
                 failures.append("download_file(validation)")

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -24,7 +24,7 @@ def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -
     mock_client.tts.generate.return_value = mock_response
 
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"), patch(
-        "cartesia_mcp.server._try_cloud_download_url",
+        "cartesia_mcp.server._try_create_download_link",
         return_value="https://example.com/link",
     ):
         server.text_to_speech(

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -24,7 +24,7 @@ def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -
     mock_client.tts.generate.return_value = mock_response
 
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"), patch(
-        "cartesia_mcp.server._cloud_download_url",
+        "cartesia_mcp.server._try_cloud_download_url",
         return_value="https://example.com/link",
     ):
         server.text_to_speech(

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -19,11 +19,14 @@ def test_stt_words_from_timestamps_flattens_word_timestamps() -> None:
 
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -> None:
-    mock_client.tts.generate.return_value = MagicMock(read=lambda: b"audio")
+    mock_response = MagicMock(read=lambda: b"audio")
+    mock_response.headers = {"Cartesia-File-ID": "file_test"}
+    mock_client.tts.generate.return_value = mock_response
 
-    with patch("cartesia_mcp.server.create_output_file") as mock_output:
-        mock_output.return_value.open.return_value.__enter__ = MagicMock()
-        mock_output.return_value.open.return_value.__exit__ = MagicMock(return_value=False)
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"), patch(
+        "cartesia_mcp.server._cloud_download_url",
+        return_value="https://example.com/link",
+    ):
         server.text_to_speech(
             transcript="hello",
             voice={"mode": "id", "id": "voice-id"},
@@ -33,6 +36,7 @@ def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -
 
     kwargs = mock_client.tts.generate.call_args.kwargs
     assert kwargs["extra_body"] == {"duration": 12.5}
+    assert kwargs["save"] is True
 
 
 @patch("cartesia_mcp.server.client")

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -80,6 +80,27 @@ def test_text_to_speech_save_false_overrides_extra_body_save(
     assert "file_id" not in result
 
 
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_save_flag_does_not_mutate_request_options(
+    mock_client: MagicMock,
+) -> None:
+    mock_response = MagicMock(read=lambda: b"audio-bytes")
+    mock_response.headers = {}
+    mock_client.tts.generate.return_value = mock_response
+    request_options = {"extra_json": {"save": True, "duration": 1.5}}
+
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
+        server.text_to_speech(
+            transcript="Hello",
+            voice={"mode": "id", "id": "voice_abc"},
+            output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
+            save=False,
+            request_options=request_options,
+        )
+
+    assert request_options["extra_json"] == {"save": True, "duration": 1.5}
+
+
 @patch("cartesia_mcp.server._try_create_download_link")
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_save_returns_cloud_ids(

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -56,7 +56,7 @@ def test_download_file_returns_url_and_local_path(
     }
 
 
-@patch("cartesia_mcp.server._try_cloud_download_url")
+@patch("cartesia_mcp.server._try_create_download_link")
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_save_returns_cloud_ids(
     mock_client: MagicMock,
@@ -86,7 +86,7 @@ def test_text_to_speech_save_returns_cloud_ids(
     }
 
 
-@patch("cartesia_mcp.server._try_cloud_download_url", return_value=None)
+@patch("cartesia_mcp.server._try_create_download_link", return_value=None)
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_save_returns_file_id_when_link_fails(
     mock_client: MagicMock,
@@ -111,7 +111,7 @@ def test_text_to_speech_save_returns_file_id_when_link_fails(
 @patch("cartesia_mcp.server.save_downloaded_file")
 @patch("cartesia_mcp.server.extra_api.download_file_bytes")
 @patch("cartesia_mcp.server.extra_api.get_file_info")
-@patch("cartesia_mcp.server._try_cloud_download_url", return_value=None)
+@patch("cartesia_mcp.server._try_create_download_link", return_value=None)
 @patch("cartesia_mcp.server.client")
 def test_download_file_returns_local_path_when_link_fails(
     mock_client: MagicMock,

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -56,7 +56,7 @@ def test_download_file_returns_url_and_local_path(
     }
 
 
-@patch("cartesia_mcp.server._cloud_download_url")
+@patch("cartesia_mcp.server._try_cloud_download_url")
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_save_returns_cloud_ids(
     mock_client: MagicMock,
@@ -84,6 +84,55 @@ def test_text_to_speech_save_returns_cloud_ids(
         "download_url": "https://files.cartesia.ai/link/link_new",
         "file_path": "/tmp/out.wav",
     }
+
+
+@patch("cartesia_mcp.server._try_cloud_download_url", return_value=None)
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_save_returns_file_id_when_link_fails(
+    mock_client: MagicMock,
+    _mock_cloud_url: MagicMock,
+) -> None:
+    mock_response = MagicMock(read=lambda: b"audio-bytes")
+    mock_response.headers = {"Cartesia-File-ID": "file_new"}
+    mock_client.tts.generate.return_value = mock_response
+
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
+        result = server.text_to_speech(
+            transcript="Hello",
+            voice={"mode": "id", "id": "voice_abc"},
+            output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
+            save=True,
+        )
+
+    assert result == {"file_id": "file_new", "file_path": "/tmp/out.wav"}
+    assert "download_url" not in result
+
+
+@patch("cartesia_mcp.server.save_downloaded_file")
+@patch("cartesia_mcp.server.extra_api.download_file_bytes")
+@patch("cartesia_mcp.server.extra_api.get_file_info")
+@patch("cartesia_mcp.server._try_cloud_download_url", return_value=None)
+@patch("cartesia_mcp.server.client")
+def test_download_file_returns_local_path_when_link_fails(
+    mock_client: MagicMock,
+    _mock_cloud_url: MagicMock,
+    mock_get_file_info: MagicMock,
+    mock_download_bytes: MagicMock,
+    mock_save: MagicMock,
+) -> None:
+    _ = mock_client
+    mock_get_file_info.return_value = {"id": "file_abc", "filename": "clip.wav"}
+    mock_download_bytes.return_value = b"audio-bytes"
+    mock_save.return_value = Path("/tmp/download_clip.wav")
+
+    result = server.download_file("file_abc")
+
+    assert result == {
+        "file_id": "file_abc",
+        "file_path": "/tmp/download_clip.wav",
+        "filename": "clip.wav",
+    }
+    assert "download_url" not in result
 
 
 @patch("cartesia_mcp.server.client")

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -56,6 +56,30 @@ def test_download_file_returns_url_and_local_path(
     }
 
 
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_save_false_overrides_extra_body_save(
+    mock_client: MagicMock,
+) -> None:
+    mock_response = MagicMock(read=lambda: b"audio-bytes")
+    mock_response.headers = {"Cartesia-File-ID": "file_new"}
+    mock_client.tts.generate.return_value = mock_response
+
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
+        result = server.text_to_speech(
+            transcript="Hello",
+            voice={"mode": "id", "id": "voice_abc"},
+            output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
+            save=False,
+            request_options={"extra_json": {"save": True}},
+        )
+
+    kwargs = mock_client.tts.generate.call_args.kwargs
+    assert kwargs["save"] is False
+    assert "save" not in kwargs.get("extra_body", {})
+    assert result == {"file_path": "/tmp/out.wav"}
+    assert "file_id" not in result
+
+
 @patch("cartesia_mcp.server._try_create_download_link")
 @patch("cartesia_mcp.server.client")
 def test_text_to_speech_save_returns_cloud_ids(
@@ -152,7 +176,7 @@ def test_text_to_speech_without_save_returns_local_path_only(
             save=False,
         )
 
-    assert "save" not in mock_client.tts.generate.call_args.kwargs
+    assert mock_client.tts.generate.call_args.kwargs["save"] is False
     assert result == {"file_path": "/tmp/out.wav"}
 
 

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -12,46 +12,16 @@ def prod_files_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CARTESIA_FILES_BASE_URL", raising=False)
 
 
-@patch("cartesia_mcp.server.client")
-def test_list_files_forwards_query_params(
-    mock_client: MagicMock,
-    prod_files_base_url: None,
-) -> None:
-    mock_client.get.return_value = {"data": [], "has_more": False}
-
-    server.list_files(limit=5, purpose="tts_generation", query="demo")
-
-    mock_client.get.assert_called_once()
-    args, kwargs = mock_client.get.call_args
-    assert args[0] == extra_api._files_url("/files")
-    assert kwargs["options"] == {
-        "params": {"limit": "5", "purpose": "tts_generation", "q": "demo"},
-    }
-
-
-@patch("cartesia_mcp.server.client")
-def test_get_file_calls_info_endpoint(
-    mock_client: MagicMock,
-    prod_files_base_url: None,
-) -> None:
-    mock_client.get.return_value = {"id": "file_abc", "filename": "clip.wav"}
-
-    result = server.get_file("file_abc")
-
-    mock_client.get.assert_called_once()
-    args, _kwargs = mock_client.get.call_args
-    assert args[0] == extra_api._files_url("/files/file_abc/info")
-    assert result["filename"] == "clip.wav"
-
-
 @patch("cartesia_mcp.server.save_downloaded_file")
+@patch("cartesia_mcp.server.extra_api.create_file_download_link")
 @patch("cartesia_mcp.server.extra_api.download_file_bytes")
 @patch("cartesia_mcp.server.extra_api.get_file_info")
 @patch("cartesia_mcp.server.client")
-def test_download_file_writes_to_output_directory(
+def test_download_file_returns_url_and_local_path(
     mock_client: MagicMock,
     mock_get_file_info: MagicMock,
     mock_download_bytes: MagicMock,
+    mock_create_link: MagicMock,
     mock_save: MagicMock,
 ) -> None:
     _ = mock_client
@@ -60,6 +30,7 @@ def test_download_file_writes_to_output_directory(
         "filename": "tts-output.pcm",
     }
     mock_download_bytes.return_value = b"audio-bytes"
+    mock_create_link.return_value = "https://files.cartesia.ai/link/link_abc"
     mock_save.return_value = Path("/tmp/download_tts-output.wav")
 
     result = server.download_file("file_abc", format="playback")
@@ -70,6 +41,7 @@ def test_download_file_writes_to_output_directory(
         "file_abc",
         format="playback",
     )
+    mock_create_link.assert_called_once_with(mock_client, "file_abc")
     mock_save.assert_called_once_with(
         server.OUTPUT_DIRECTORY,
         file_id="file_abc",
@@ -77,10 +49,62 @@ def test_download_file_writes_to_output_directory(
         content=b"audio-bytes",
     )
     assert result == {
-        "file_path": "/tmp/download_tts-output.wav",
         "file_id": "file_abc",
+        "download_url": "https://files.cartesia.ai/link/link_abc?format=playback",
+        "file_path": "/tmp/download_tts-output.wav",
         "filename": "tts-output.wav",
     }
+
+
+@patch("cartesia_mcp.server._cloud_download_url")
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_save_returns_cloud_ids(
+    mock_client: MagicMock,
+    mock_cloud_url: MagicMock,
+) -> None:
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"audio-bytes"
+    mock_response.headers = {"Cartesia-File-ID": "file_new"}
+    mock_client.tts.generate.return_value = mock_response
+    mock_cloud_url.return_value = "https://files.cartesia.ai/link/link_new"
+
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
+        result = server.text_to_speech(
+            transcript="Hello",
+            voice={"mode": "id", "id": "voice_abc"},
+            output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
+            save=True,
+        )
+
+    mock_client.tts.generate.assert_called_once()
+    assert mock_client.tts.generate.call_args.kwargs["save"] is True
+    mock_cloud_url.assert_called_once_with("file_new")
+    assert result == {
+        "file_id": "file_new",
+        "download_url": "https://files.cartesia.ai/link/link_new",
+        "file_path": "/tmp/out.wav",
+    }
+
+
+@patch("cartesia_mcp.server.client")
+def test_text_to_speech_without_save_returns_local_path_only(
+    mock_client: MagicMock,
+) -> None:
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"audio-bytes"
+    mock_response.headers = {}
+    mock_client.tts.generate.return_value = mock_response
+
+    with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
+        result = server.text_to_speech(
+            transcript="Hello",
+            voice={"mode": "id", "id": "voice_abc"},
+            output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
+            save=False,
+        )
+
+    assert "save" not in mock_client.tts.generate.call_args.kwargs
+    assert result == {"file_path": "/tmp/out.wav"}
 
 
 def test_files_base_url_defaults_to_prod(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,6 +115,39 @@ def test_files_base_url_defaults_to_prod(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_files_base_url_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARTESIA_FILES_BASE_URL", "https://files.staging.example")
     assert extra_api.files_base_url() == "https://files.staging.example"
+
+
+def test_file_id_from_response_headers_is_case_insensitive() -> None:
+    assert extra_api.file_id_from_response_headers(
+        {"Cartesia-File-ID": "file_abc"},
+    ) == "file_abc"
+    assert extra_api.file_id_from_response_headers(
+        {"cartesia-file-id": "file_xyz"},
+    ) == "file_xyz"
+
+
+def test_with_download_format_appends_query() -> None:
+    assert extra_api.with_download_format(
+        "https://files.cartesia.ai/link/link_abc",
+        "playback",
+    ) == "https://files.cartesia.ai/link/link_abc?format=playback"
+
+
+@patch("cartesia_mcp.extra_api._files_url")
+def test_create_file_download_link_posts_lifetime(
+    mock_files_url: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_files_url.return_value = "https://files.cartesia.ai/links"
+    mock_client.post.return_value = {"url": "https://files.cartesia.ai/link/link_abc"}
+
+    url = extra_api.create_file_download_link(mock_client, "file_abc", lifetime_hours=24)
+
+    mock_client.post.assert_called_once()
+    args, kwargs = mock_client.post.call_args
+    assert args[0] == "https://files.cartesia.ai/links"
+    assert kwargs["body"] == {"file_id": "file_abc", "lifetime": "24h"}
+    assert url == "https://files.cartesia.ai/link/link_abc"
 
 
 def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -7,7 +7,7 @@ import cartesia_mcp.server as server
 
 def test_all_tools_have_title_and_hint():
     tools = server.mcp._tool_manager.list_tools()
-    assert len(tools) == 18
+    assert len(tools) == 16
 
     for tool in tools:
         assert tool.title, f"{tool.name} is missing title"
@@ -20,9 +20,7 @@ def test_all_tools_have_title_and_hint():
 def test_read_only_tools():
     read_only = {
         "download_file",
-        "get_file",
         "get_voice",
-        "list_files",
         "list_voices",
         "speech_to_text",
         "get_credit_usage",

--- a/tests/test_tool_visibility.py
+++ b/tests/test_tool_visibility.py
@@ -42,7 +42,7 @@ def test_list_tools_hides_admin_tools_without_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 17
+    assert len(names) == 15
     assert "get_credit_usage" not in names
 
 
@@ -53,5 +53,5 @@ def test_list_tools_shows_admin_tools_with_credential(monkeypatch):
     )
     tools = asyncio.run(server.mcp.list_tools())
     names = {tool.name for tool in tools}
-    assert len(names) == 18
+    assert len(names) == 16
     assert "get_credit_usage" in names


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/PSE-19/add-mcp-support-for-files-api

## Summary

MCP TTS now matches the bytes API `save=true` flow: generations persist to org cloud storage and tools return `file_id` plus a 24-hour `download_url` (public share link for hosted clients like Claude). Local `uvx` also gets `file_path` on the MCP host for same-session `speech_to_text`. Removed `list_files` / `get_file` — chat flow is generate → fetch by ID.

## Changes

- `text_to_speech`: `save` param (default `true`); returns `file_id`, `download_url`, and `file_path`
- `download_file`: fetch by `file_id`; same return shape
- `extra_api`: `create_file_download_link`, `file_id_from_response_headers`, `with_download_format`
- Best-effort link minting (`_try_create_download_link`) — TTS/download still succeed if `POST /links` fails; omit `download_url` and retry via `download_file`
- Removed `list_files` and `get_file` MCP tools
- Tests + smoke script updated

## Test plan

- [x] `uv run pytest` (74 tests)
- [ ] `uv run python scripts/test_all_tools.py` (live API)
- [ ] Hosted MCP: `text_to_speech` → open `download_url` in browser

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default TTS cloud persistence and removal of list/get file tools change MCP behavior and may break clients that relied on browsing cloud files; link minting is best-effort so hosted clients may need `download_file` retries.
> 
> **Overview**
> **`text_to_speech`** now defaults to **`save=true`**, matching the bytes API: generations are stored in org cloud storage, the tool still writes **`file_path`** on the MCP host, and when saving it returns **`file_id`** plus a best-effort **24h `download_url`** (from `POST /links`). **`save=false`** returns only the local path; the tool-level **`save`** overrides any `save` in `request_options`. Missing **`Cartesia-File-ID`** when save is on raises **`RuntimeError`**.
> 
> **`download_file`** is refactored through **`_deliver_cloud_file`**: same shape as saved TTS (**`download_url`**, local copy, **`filename`**). Link minting failures omit **`download_url`** without failing the tool.
> 
> **Removed** MCP tools **`list_files`** and **`get_file`** (and **`ListFilesResult`**); workflow is generate → fetch by ID. **`extra_api`** swaps **`list_files`** for **`create_file_download_link`**, plus **`file_id_from_response_headers`** and **`with_download_format`**.
> 
> README, smoke script, and tests updated (tool count 16).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19be963063fa60a97064120e5502943b8aa1f177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->