### PR TITLE
fix: Claude directory tool annotations and voice_id param

### DIFF
--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -73,8 +73,20 @@ elif CARTESIA_API_KEY:
 
 mcp = CartesiaMCP("Cartesia", **(fastmcp_hosted_kwargs() if _is_hosted else {}))
 
-_READ_ONLY = ToolAnnotations(readOnlyHint=True)
-_WRITE = ToolAnnotations(destructiveHint=True)
+def _read_only_tool(title: str) -> ToolAnnotations:
+    return ToolAnnotations(title=title, readOnlyHint=True)
+
+
+def _additive_tool(title: str) -> ToolAnnotations:
+    return ToolAnnotations(title=title, readOnlyHint=False, destructiveHint=False)
+
+
+def _destructive_tool(title: str) -> ToolAnnotations:
+    return ToolAnnotations(title=title, readOnlyHint=False, destructiveHint=True)
+
+
+def _voice_from_id(voice_id: str) -> VoiceSpecifierParam:
+    return VoiceSpecifierParam(mode="id", id=voice_id)
 
 
 def _require_admin_client() -> Cartesia:
@@ -210,8 +222,7 @@ def _deliver_cloud_file(
 
 
 @mcp.tool(
-    title="Convert text to speech",
-    annotations=_WRITE,
+    annotations=_additive_tool("Convert text to speech"),
     description="""
         Generate speech audio from text. By default (`save=true`) the audio is persisted
         in Cartesia cloud storage and the response includes `file_id` and `download_url`
@@ -223,7 +234,8 @@ def _deliver_cloud_file(
         ----------
         transcript : str
 
-        voice : TtsRequestVoiceSpecifierParams
+        voice_id : str
+            Cartesia voice ID (e.g. from `list_voices`).
 
         output_format : OutputFormatParams
 
@@ -259,7 +271,7 @@ def _deliver_cloud_file(
           """)
 def text_to_speech(
     transcript: str,
-    voice: VoiceSpecifierParam,
+    voice_id: str,
     output_format: OutputFormat,
     model_id: typing.Optional[str] = DEFAULT_MODEL_ID,
     language: typing.Optional[SupportedLanguage] = None,
@@ -278,7 +290,7 @@ def text_to_speech(
     )
     tts_kwargs: dict[str, typing.Any] = {
         "transcript": transcript,
-        "voice": voice,
+        "voice": _voice_from_id(voice_id),
         "output_format": output_format,
         "model_id": model_id,
         "language": language,
@@ -319,8 +331,7 @@ def text_to_speech(
 
 
 @mcp.tool(
-    title="Change voice in audio",
-    annotations=_WRITE,
+    annotations=_additive_tool("Change voice in audio"),
     description="""
         Takes an audio file of speech, and returns an audio file of speech spoken with the same intonation, but with a different voice.
 
@@ -375,8 +386,7 @@ def voice_change(
     return GeneratedAudioResult(file_path=file_path)
 
 @mcp.tool(
-    title="Localize voice",
-    annotations=_WRITE,
+    annotations=_additive_tool("Localize voice"),
     description="""
         Create a new voice from an existing voice localized to a new language and dialect.
 
@@ -421,8 +431,7 @@ def localize_voice(
 
 
 @mcp.tool(
-    title="Delete voice",
-    annotations=_WRITE,
+    annotations=_destructive_tool("Delete voice"),
     description="""
         Parameters
         ----------
@@ -440,8 +449,7 @@ def delete_voice(
     return DeleteVoiceResult(success=True)
 
 @mcp.tool(
-    title="Get voice",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("Get voice"),
     description="""
         Parameters
         ----------
@@ -459,8 +467,7 @@ def get_voice(
 
 
 @mcp.tool(
-    title="Update voice",
-    annotations=_WRITE,
+    annotations=_destructive_tool("Update voice"),
     description="""
         Parameters
         ----------
@@ -489,8 +496,7 @@ def update_voice(
     )
 
 @mcp.tool(
-    title="Clone voice",
-    annotations=_WRITE,
+    annotations=_additive_tool("Clone voice"),
     description="""
         Clone a voice from an audio clip. This endpoint has two modes, stability and similarity.
 
@@ -538,8 +544,7 @@ def clone_voice(
         )
 
 @mcp.tool(
-    title="List voices",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("List voices"),
     description="""
         Parameters
         ----------
@@ -781,8 +786,7 @@ def _speech_to_text_stream(
 
 
 @mcp.tool(
-    title="Transcribe audio",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("Transcribe audio"),
     description="""
         Transcribe a pre-recorded audio file to text.
 
@@ -855,8 +859,7 @@ def speech_to_text(
 
 
 @mcp.tool(
-    title="Download file",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("Download file"),
     description="""
         Fetch a Cartesia cloud-stored file by ID. Returns a 24-hour `download_url` for
         hosted and remote clients. Also writes a copy to `OUTPUT_DIRECTORY` on the MCP
@@ -881,8 +884,7 @@ def download_file(
 
 
 @mcp.tool(
-    title="Get credit usage",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("Get credit usage"),
     description="""
         Returns credit usage over time (`GET /usage/credits`).
 
@@ -917,8 +919,7 @@ def get_credit_usage(
 
 
 @mcp.tool(
-    title="List pronunciation dictionaries",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("List pronunciation dictionaries"),
     description="""
         List pronunciation dictionaries for the authenticated user.
 
@@ -947,8 +948,7 @@ def list_pronunciation_dicts(
 
 
 @mcp.tool(
-    title="Create pronunciation dictionary",
-    annotations=_WRITE,
+    annotations=_additive_tool("Create pronunciation dictionary"),
     description="""
         Create a pronunciation dictionary.
 
@@ -970,8 +970,7 @@ def create_pronunciation_dict(
 
 
 @mcp.tool(
-    title="Get pronunciation dictionary",
-    annotations=_READ_ONLY,
+    annotations=_read_only_tool("Get pronunciation dictionary"),
     description="""
         Parameters
         ----------
@@ -983,8 +982,7 @@ def get_pronunciation_dict(dict_id: str) -> dict[str, typing.Any]:
 
 
 @mcp.tool(
-    title="Update pronunciation dictionary",
-    annotations=_WRITE,
+    annotations=_destructive_tool("Update pronunciation dictionary"),
     description="""
         Update a pronunciation dictionary.
 
@@ -1012,8 +1010,7 @@ def update_pronunciation_dict(
 
 
 @mcp.tool(
-    title="Delete pronunciation dictionary",
-    annotations=_WRITE,
+    annotations=_destructive_tool("Delete pronunciation dictionary"),
     description="""
         Parameters
         ----------

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -136,7 +136,7 @@ def main() -> int:
                 "This is a longer Cartesia MCP smoke test clip. "
                 "We need several seconds of speech for voice cloning to succeed."
             ),
-            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            voice_id=SAMPLE_VOICE_ID,
             output_format=WAV_FORMAT,
             language="en",
             speed=1.0,
@@ -248,7 +248,7 @@ def main() -> int:
                 "text_to_speech(pronunciation_dict)",
                 lambda: s.text_to_speech(
                     transcript="Welcome to Cartesia.",
-                    voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+                    voice_id=SAMPLE_VOICE_ID,
                     output_format=WAV_FORMAT,
                     pronunciation_dict_id=dict_id,
                 ),

--- a/tests/test_bugbot_regressions.py
+++ b/tests/test_bugbot_regressions.py
@@ -29,7 +29,7 @@ def test_text_to_speech_passes_duration_via_extra_body(mock_client: MagicMock) -
     ):
         server.text_to_speech(
             transcript="hello",
-            voice={"mode": "id", "id": "voice-id"},
+            voice_id="voice-id",
             output_format={"container": "wav", "sample_rate": 44100},
             duration=12.5,
         )

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -67,7 +67,7 @@ def test_text_to_speech_save_false_overrides_extra_body_save(
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
         result = server.text_to_speech(
             transcript="Hello",
-            voice={"mode": "id", "id": "voice_abc"},
+            voice_id="voice_abc",
             output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
             save=False,
             request_options={"extra_json": {"save": True}},
@@ -92,7 +92,7 @@ def test_text_to_speech_save_flag_does_not_mutate_request_options(
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
         server.text_to_speech(
             transcript="Hello",
-            voice={"mode": "id", "id": "voice_abc"},
+            voice_id="voice_abc",
             output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
             save=False,
             request_options=request_options,
@@ -116,7 +116,7 @@ def test_text_to_speech_save_returns_cloud_ids(
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
         result = server.text_to_speech(
             transcript="Hello",
-            voice={"mode": "id", "id": "voice_abc"},
+            voice_id="voice_abc",
             output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
             save=True,
         )
@@ -144,7 +144,7 @@ def test_text_to_speech_save_returns_file_id_when_link_fails(
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
         result = server.text_to_speech(
             transcript="Hello",
-            voice={"mode": "id", "id": "voice_abc"},
+            voice_id="voice_abc",
             output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
             save=True,
         )
@@ -192,7 +192,7 @@ def test_text_to_speech_without_save_returns_local_path_only(
     with patch("cartesia_mcp.server._write_audio_output", return_value="/tmp/out.wav"):
         result = server.text_to_speech(
             transcript="Hello",
-            voice={"mode": "id", "id": "voice_abc"},
+            voice_id="voice_abc",
             output_format={"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100},
             save=False,
         )

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,20 +1,30 @@
-"""Anthropic Connectors Directory requires title and read/destructive hints on every tool."""
+"""Anthropic Connectors Directory requires annotations.title and read/destructive hints."""
 
 from __future__ import annotations
+
+import asyncio
 
 import cartesia_mcp.server as server
 
 
-def test_all_tools_have_title_and_hint():
+def test_all_tools_have_annotation_title_and_hint():
     tools = server.mcp._tool_manager.list_tools()
     assert len(tools) == 16
 
     for tool in tools:
-        assert tool.title, f"{tool.name} is missing title"
         assert tool.annotations is not None, f"{tool.name} is missing annotations"
-        assert (
-            tool.annotations.readOnlyHint or tool.annotations.destructiveHint
-        ), f"{tool.name} must set readOnlyHint or destructiveHint"
+        assert tool.annotations.title, f"{tool.name} is missing annotations.title"
+        assert tool.annotations.readOnlyHint is not None, (
+            f"{tool.name} must set readOnlyHint explicitly"
+        )
+        if tool.annotations.readOnlyHint:
+            assert tool.annotations.destructiveHint in (None, False), (
+                f"{tool.name} is read-only but sets destructiveHint"
+            )
+        else:
+            assert tool.annotations.destructiveHint is not None, (
+                f"{tool.name} must set destructiveHint when readOnlyHint is false"
+            )
 
 
 def test_read_only_tools():
@@ -29,23 +39,52 @@ def test_read_only_tools():
     }
     tools = {tool.name: tool for tool in server.mcp._tool_manager.list_tools()}
     for name in read_only:
-        assert tools[name].annotations is not None
-        assert tools[name].annotations.readOnlyHint is True
+        annotations = tools[name].annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint in (None, False)
 
 
-def test_write_tools():
-    write_tools = {
+def test_additive_tools():
+    additive_tools = {
         "text_to_speech",
         "voice_change",
         "localize_voice",
-        "delete_voice",
-        "update_voice",
         "clone_voice",
         "create_pronunciation_dict",
+    }
+    tools = {tool.name: tool for tool in server.mcp._tool_manager.list_tools()}
+    for name in additive_tools:
+        annotations = tools[name].annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is False
+        assert annotations.destructiveHint is False
+
+
+def test_destructive_tools():
+    destructive_tools = {
+        "delete_voice",
+        "update_voice",
         "update_pronunciation_dict",
         "delete_pronunciation_dict",
     }
     tools = {tool.name: tool for tool in server.mcp._tool_manager.list_tools()}
-    for name in write_tools:
-        assert tools[name].annotations is not None
-        assert tools[name].annotations.destructiveHint is True
+    for name in destructive_tools:
+        annotations = tools[name].annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is False
+        assert annotations.destructiveHint is True
+
+
+def test_wire_format_exposes_annotation_title():
+    tools = asyncio.run(server.mcp.list_tools())
+    for tool in tools:
+        assert tool.annotations is not None
+        assert tool.annotations.title
+
+
+def test_text_to_speech_voice_id_has_string_type():
+    tools = asyncio.run(server.mcp.list_tools())
+    tts = next(tool for tool in tools if tool.name == "text_to_speech")
+    voice_id = tts.inputSchema["properties"]["voice_id"]
+    assert voice_id["type"] == "string"


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1346/submit-cartesia-mcp-to-claude-connectors-directory

## Summary

Fixes Claude Connectors Directory validation failures on the Tools step: missing `annotations.title`, missing explicit `readOnlyHint`, over-broad `destructiveHint`, and the `text_to_speech` `voice` parameter schema error.

## Changes

- Put human-readable titles in `ToolAnnotations.title` (not only top-level `Tool.title`)
- Classify tools into read-only, additive write, and destructive write annotations
- Change `text_to_speech` to accept `voice_id: str` instead of a nested `VoiceSpecifierParam` object
- Update annotation and TTS tests

## Test plan

- [x] `CARTESIA_API_KEY=test uv run pytest tests/test_tool_annotations.py tests/test_files_api.py tests/test_bugbot_regressions.py`
- [ ] After deploy: disconnect/reconnect custom connector in Claude and confirm Tools page shows 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for MCP clients that still pass a nested `voice` object to `text_to_speech`; runtime TTS behavior is unchanged aside from the new parameter shape.
> 
> **Overview**
> Addresses **Claude Connectors Directory** tool validation by moving human-readable titles into **`ToolAnnotations.title`**, setting **explicit `readOnlyHint`**, and splitting writes into **additive** (`destructiveHint=false`) vs **destructive** tools instead of marking every mutating tool as destructive.
> 
> **`text_to_speech`** now takes a flat **`voice_id: str`** (mapped internally to the SDK voice specifier) so the published input schema is a simple string rather than a nested `VoiceSpecifierParam` object.
> 
> Tests and the **`scripts/test_all_tools.py`** smoke script were updated for **`voice_id`**, with expanded annotation coverage (additive/destructive groupings and wire-format **`annotations.title`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00be4efeb2bd5dca017a83c79c26e677a1fe3534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->