### PR TITLE
feat: add group_by to get_credit_usage MCP tool

### DIFF
--- a/cartesia_mcp/extra_api.py
+++ b/cartesia_mcp/extra_api.py
@@ -18,6 +18,7 @@ from cartesia import Cartesia
 from cartesia_mcp.config import env_or_none
 
 UsageInterval = typing.Literal["day", "week", "month"]
+UsageCreditsGroupBy = typing.Literal["capability", "model", "voice", "api_key"]
 DownloadFormat = typing.Literal["playback"]
 
 DEFAULT_FILES_BASE_URL = "https://files.cartesia.ai"
@@ -57,6 +58,7 @@ def get_usage_credits(
     end_ts: typing.Optional[str] = None,
     interval: typing.Optional[UsageInterval] = None,
     api_key_id: typing.Optional[str] = None,
+    group_by: typing.Optional[UsageCreditsGroupBy] = None,
 ) -> dict[str, typing.Any]:
     params: dict[str, str] = {}
     if start_ts is not None:
@@ -67,6 +69,8 @@ def get_usage_credits(
         params["interval"] = interval
     if api_key_id is not None:
         params["api_key_id"] = api_key_id
+    if group_by is not None:
+        params["group_by"] = group_by
     return client.get(
         "/usage/credits",
         cast_to=dict[str, typing.Any],

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -37,7 +37,7 @@ from cartesia_mcp.custom_types import (
 )
 from cartesia_mcp.constants import DEFAULT_MODEL_ID
 from cartesia_mcp import extra_api
-from cartesia_mcp.extra_api import DownloadFormat, UsageInterval
+from cartesia_mcp.extra_api import DownloadFormat, UsageCreditsGroupBy, UsageInterval
 from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_keys
 from cartesia_mcp.clients import admin_client, client, require_admin_client
 from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
@@ -902,12 +902,17 @@ def download_file(
 
         api_key_id : typing.Optional[str]
             Limit usage to a specific API key ID.
+
+        group_by : typing.Optional[UsageCreditsGroupBy]
+            Break down usage by capability, model, voice, or API key. Requires
+            `interval=day`.
         """)
 def get_credit_usage(
     start_ts: typing.Optional[str] = None,
     end_ts: typing.Optional[str] = None,
     interval: typing.Optional[UsageInterval] = None,
     api_key_id: typing.Optional[str] = None,
+    group_by: typing.Optional[UsageCreditsGroupBy] = None,
 ) -> dict[str, typing.Any]:
     return extra_api.get_usage_credits(
         _require_admin_client(),
@@ -915,6 +920,7 @@ def get_credit_usage(
         end_ts=end_ts,
         interval=interval,
         api_key_id=api_key_id,
+        group_by=group_by,
     )
 
 

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -904,8 +904,9 @@ def download_file(
             Limit usage to a specific API key ID.
 
         group_by : typing.Optional[UsageCreditsGroupBy]
-            Break down usage by capability, model, voice, or API key. Requires
-            `interval=day`.
+            Break down usage by capability, model, voice, or API key. When
+            `interval` is set it must be `day`. Grouped responses use
+            `{ group_by, data: [{ id, label?, buckets }] }`.
         """)
 def get_credit_usage(
     start_ts: typing.Optional[str] = None,

--- a/tests/test_usage_credits_api.py
+++ b/tests/test_usage_credits_api.py
@@ -15,15 +15,5 @@ def test_get_usage_credits_forwards_group_by() -> None:
         group_by="model",
     )
 
-    client.get.assert_called_once_with(
-        "/usage/credits",
-        cast_to=dict[str, object],
-        options={
-            "params": {
-                "start_ts": "2026-01-01T00:00:00Z",
-                "end_ts": "2026-01-08T00:00:00Z",
-                "interval": "day",
-                "group_by": "model",
-            }
-        },
-    )
+    client.get.assert_called_once()
+    assert client.get.call_args.kwargs["options"]["params"]["group_by"] == "model"

--- a/tests/test_usage_credits_api.py
+++ b/tests/test_usage_credits_api.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+import cartesia_mcp.extra_api as extra_api
+
+
+def test_get_usage_credits_forwards_group_by() -> None:
+    client = MagicMock()
+    client.get.return_value = {"data": []}
+
+    extra_api.get_usage_credits(
+        client,
+        start_ts="2026-01-01T00:00:00Z",
+        end_ts="2026-01-08T00:00:00Z",
+        interval="day",
+        group_by="model",
+    )
+
+    client.get.assert_called_once_with(
+        "/usage/credits",
+        cast_to=dict[str, object],
+        options={
+            "params": {
+                "start_ts": "2026-01-01T00:00:00Z",
+                "end_ts": "2026-01-08T00:00:00Z",
+                "interval": "day",
+                "group_by": "model",
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds optional `group_by` to `get_credit_usage` so clients can break down Admin API credit usage by capability, model, voice, or API key.

## Changes

- Add `group_by` parameter (`capability` | `model` | `voice` | `api_key`) to `get_credit_usage` / `get_usage_credits`
- Document that grouped responses use `{ group_by, data: [{ id, label?, buckets }] }`
- Unit test that `group_by` is forwarded in query params

## Test plan

- [ ] Call `get_credit_usage` with `group_by=capability` and `interval=day` against an org that has credit usage
- [ ] Confirm `group_by` appears in the forwarded request params (existing unit test)