### PR TITLE
feat: persist hosted OAuth tokens in Redis with refresh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,16 @@ jobs:
   docker-build:
     name: docker build
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
 
@@ -38,7 +48,10 @@ jobs:
 
       - name: Smoke test /health
         run: |
-          docker run -d --name mcp-ci -p 8000:8000 cartesia-mcp:ci
+          docker run -d --name mcp-ci -p 8000:8000 \
+            --add-host=host.docker.internal:host-gateway \
+            -e REDIS_URL=redis://host.docker.internal:6379/0 \
+            cartesia-mcp:ci
           for i in $(seq 1 30); do
             if curl -sf http://localhost:8000/health; then
               exit 0

--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -14,6 +14,7 @@ from starlette.routing import Route
 
 from cartesia_mcp.config import env_or_none
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+from cartesia_mcp.oauth_store import configure_oauth_store_from_env
 
 
 def hosted_enabled() -> bool:
@@ -21,6 +22,14 @@ def hosted_enabled() -> bool:
     if value is None:
         return False
     return value.lower() in ("1", "true", "yes", "on")
+
+
+def configure_hosted_oauth_store() -> None:
+    """Require Redis for hosted OAuth state (fail closed if REDIS_URL is missing)."""
+    configure_oauth_store_from_env(
+        hosted=True,
+        redis_url=env_or_none("REDIS_URL"),
+    )
 
 
 def server_public_url() -> str:
@@ -159,5 +168,7 @@ def attach_hosted_routes(mcp: FastMCP) -> None:
 
 
 def run_hosted(mcp: FastMCP) -> None:
+    if hosted_enabled():
+        configure_hosted_oauth_store()
     attach_hosted_routes(mcp)
     mcp.run(transport="streamable-http")

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -105,10 +105,13 @@ class CartesiaOAuthProvider(
             set_hosted_admin_credential(stored.cartesia_admin_credential)
 
             return AccessToken(
+                # Tools resolve Cartesia credentials from AccessToken.token.
                 token=stored.cartesia_credential,
                 client_id=stored.client_id,
                 scopes=stored.scopes or ["mcp"],
                 expires_at=stored.expires_at,
+                # Opaque MCP bearer (Redis key); used by revoke_token.
+                claims={"mcp_access_token": token},
             )
 
         from cartesia_mcp.credentials import is_valid_bearer_credential
@@ -127,6 +130,11 @@ class CartesiaOAuthProvider(
         self,
         token: AccessToken | RefreshToken,
     ) -> None:
+        if isinstance(token, AccessToken):
+            mcp_bearer = (token.claims or {}).get("mcp_access_token")
+            if isinstance(mcp_bearer, str) and mcp_bearer:
+                oauth_store.revoke_token(mcp_bearer)
+            return
         oauth_store.revoke_token(token.token)
 
     def build_resume_redirect(

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import secrets
-from typing import Any
 from urllib.parse import urlencode
 
 from mcp.server.auth.provider import (
@@ -11,13 +10,14 @@ from mcp.server.auth.provider import (
     AuthorizationCode,
     AuthorizationParams,
     OAuthAuthorizationServerProvider,
+    RefreshToken,
     RegistrationError,
     TokenError,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import AnyUrl
 
-from cartesia_mcp.oauth_store import oauth_store
+from cartesia_mcp.oauth_store import PendingConnectSession, oauth_store
 
 _ALLOWED_REDIRECT_SCHEMES = ("cursor:", "vscode:", "http:", "https:")
 
@@ -28,7 +28,7 @@ def _redirect_uri_is_allowed(redirect_uri: AnyUrl) -> bool:
 
 
 class CartesiaOAuthProvider(
-    OAuthAuthorizationServerProvider[AuthorizationCode, Any, AuthorizationCode]
+    OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]
 ):
     def __init__(self, *, playground_url: str, mcp_server_url: str) -> None:
         self._playground_url = playground_url.rstrip("/")
@@ -83,19 +83,19 @@ class CartesiaOAuthProvider(
         self,
         client: OAuthClientInformationFull,
         refresh_token: str,
-    ) -> None:
-        return None
+    ) -> RefreshToken | None:
+        return oauth_store.load_refresh_token(client, refresh_token)
 
     async def exchange_refresh_token(
         self,
         client: OAuthClientInformationFull,
-        refresh_token: Any,
+        refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        raise TokenError(
-            error="unsupported_grant_type",
-            error_description="Refresh tokens are not supported",
-        )
+        try:
+            return oauth_store.exchange_refresh_token(client, refresh_token, scopes)
+        except ValueError as exc:
+            raise TokenError(error="invalid_grant", error_description=str(exc)) from exc
 
     async def load_access_token(self, token: str) -> AccessToken | None:
         stored = oauth_store.resolve_mcp_access_token(token)
@@ -125,12 +125,15 @@ class CartesiaOAuthProvider(
 
     async def revoke_token(
         self,
-        token: Any,
+        token: AccessToken | RefreshToken,
     ) -> None:
-        if isinstance(token, str):
-            oauth_store._mcp_tokens.pop(token, None)
+        oauth_store.revoke_token(token.token)
 
-    def build_resume_redirect(self, session_id: str, pending) -> str:
+    def build_resume_redirect(
+        self,
+        session_id: str,
+        pending: PendingConnectSession,
+    ) -> str:
         auth_code = oauth_store.issue_authorization_code(
             client_id=pending.client_id,
             params=pending.params,
@@ -165,7 +168,11 @@ def ensure_dynamic_client(client_id: str, redirect_uri: AnyUrl) -> OAuthClientIn
 
 def register_ephemeral_client(redirect_uri: str | None = None) -> OAuthClientInformationFull:
     client_id = secrets.token_urlsafe(16)
-    redirect_uris = [AnyUrl(redirect_uri)] if redirect_uri else [AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback")]
+    redirect_uris = (
+        [AnyUrl(redirect_uri)]
+        if redirect_uri
+        else [AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback")]
+    )
     client = OAuthClientInformationFull(
         client_id=client_id,
         client_secret=None,

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -64,6 +64,8 @@ class StoredMcpRefreshToken:
 class StoreBackend(Protocol):
     def get_json(self, key: str) -> dict[str, Any] | None: ...
 
+    def pop_json(self, key: str) -> dict[str, Any] | None: ...
+
     def set_json(
         self,
         key: str,
@@ -88,6 +90,15 @@ class MemoryBackend:
         value, expires_at = entry
         if expires_at is not None and expires_at < time.time():
             self._data.pop(key, None)
+            return None
+        return value
+
+    def pop_json(self, key: str) -> dict[str, Any] | None:
+        entry = self._data.pop(key, None)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and expires_at < time.time():
             return None
         return value
 
@@ -117,6 +128,13 @@ class RedisBackend:
 
     def get_json(self, key: str) -> dict[str, Any] | None:
         raw = self._redis.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    def pop_json(self, key: str) -> dict[str, Any] | None:
+        # GETDEL is atomic — only one redeeming request can win.
+        raw = self._redis.getdel(key)
         if raw is None:
             return None
         return json.loads(raw)
@@ -520,9 +538,9 @@ class OAuthStore:
         client: OAuthClientInformationFull,
         authorization_code: AuthorizationCode,
     ) -> OAuthToken:
-        creds = self._backend.get_json(f"{_KEY_CODE_CREDENTIALS}{authorization_code.code}")
+        # Atomic pop so concurrent exchanges cannot both mint token pairs.
+        creds = self._backend.pop_json(f"{_KEY_CODE_CREDENTIALS}{authorization_code.code}")
         self._backend.delete(f"{_KEY_AUTH_CODE}{authorization_code.code}")
-        self._backend.delete(f"{_KEY_CODE_CREDENTIALS}{authorization_code.code}")
         if creds is None:
             raise ValueError("Authorization code not found")
         if creds.get("client_id") != client.client_id:
@@ -570,7 +588,8 @@ class OAuthStore:
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        data = self._backend.get_json(f"{_KEY_REFRESH}{refresh_token.token}")
+        # Atomic pop so concurrent refreshes cannot both mint token pairs.
+        data = self._backend.pop_json(f"{_KEY_REFRESH}{refresh_token.token}")
         if data is None:
             raise ValueError("Refresh token not found")
         stored = _refresh_from_dict(data)
@@ -585,7 +604,6 @@ class OAuthStore:
 
         if stored.access_token:
             self._backend.delete(f"{_KEY_ACCESS}{stored.access_token}")
-        self._backend.delete(f"{_KEY_REFRESH}{refresh_token.token}")
 
         return self._issue_token_pair(
             client_id=client.client_id,

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -1,14 +1,30 @@
-"""In-memory OAuth state for hosted MCP (single-process; replace with Redis for scale)."""
+"""OAuth state for hosted MCP (in-memory for tests; Redis required when hosted)."""
 
 from __future__ import annotations
 
+import json
 import secrets
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
-from mcp.server.auth.provider import AuthorizationCode, AuthorizationParams
+from mcp.server.auth.provider import AuthorizationCode, AuthorizationParams, RefreshToken
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+
+AUTH_CODE_TTL_SECONDS = 600
+PENDING_SESSION_TTL_SECONDS = 600
+COMPLETED_SESSION_TTL_SECONDS = 600
+ACCESS_TOKEN_TTL_SECONDS = 24 * 60 * 60
+REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60
+
+_KEY_CLIENT = "mcp:oauth:client:"
+_KEY_PENDING = "mcp:oauth:pending:"
+_KEY_COMPLETED = "mcp:oauth:completed:"
+_KEY_AUTH_CODE = "mcp:oauth:code:"
+_KEY_CODE_CREDENTIALS = "mcp:oauth:code-cred:"
+_KEY_ACCESS = "mcp:oauth:access:"
+_KEY_REFRESH = "mcp:oauth:refresh:"
 
 
 @dataclass
@@ -31,21 +47,245 @@ class StoredMcpAccessToken:
     scopes: list[str]
     expires_at: int
     cartesia_admin_credential: str | None = None
+    refresh_token: str | None = None
+
+
+@dataclass
+class StoredMcpRefreshToken:
+    token: str
+    cartesia_credential: str
+    client_id: str
+    scopes: list[str]
+    expires_at: int
+    cartesia_admin_credential: str | None = None
+    access_token: str | None = None
+
+
+class StoreBackend(Protocol):
+    def get_json(self, key: str) -> dict[str, Any] | None: ...
+
+    def set_json(
+        self,
+        key: str,
+        value: dict[str, Any],
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None: ...
+
+    def delete(self, key: str) -> None: ...
+
+    def clear(self) -> None: ...
+
+
+class MemoryBackend:
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[dict[str, Any], float | None]] = {}
+
+    def get_json(self, key: str) -> dict[str, Any] | None:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and expires_at < time.time():
+            self._data.pop(key, None)
+            return None
+        return value
+
+    def set_json(
+        self,
+        key: str,
+        value: dict[str, Any],
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
+        self._data[key] = (value, expires_at)
+
+    def delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+
+class RedisBackend:
+    def __init__(self, redis_url: str) -> None:
+        import redis
+
+        self._redis = redis.from_url(redis_url, decode_responses=True)
+        self._redis.ping()
+
+    def get_json(self, key: str) -> dict[str, Any] | None:
+        raw = self._redis.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    def set_json(
+        self,
+        key: str,
+        value: dict[str, Any],
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        payload = json.dumps(value)
+        if ttl_seconds is None:
+            self._redis.set(key, payload)
+        else:
+            self._redis.setex(key, ttl_seconds, payload)
+
+    def delete(self, key: str) -> None:
+        self._redis.delete(key)
+
+    def clear(self) -> None:
+        raise RuntimeError("RedisBackend.clear() is not supported in production")
+
+
+def _params_to_dict(params: AuthorizationParams) -> dict[str, Any]:
+    return {
+        "state": params.state,
+        "scopes": list(params.scopes or []),
+        "code_challenge": params.code_challenge,
+        "redirect_uri": str(params.redirect_uri),
+        "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
+        "resource": params.resource,
+    }
+
+
+def _params_from_dict(data: dict[str, Any]) -> AuthorizationParams:
+    return AuthorizationParams(
+        state=data.get("state"),
+        scopes=data.get("scopes"),
+        code_challenge=data["code_challenge"],
+        redirect_uri=AnyUrl(data["redirect_uri"]),
+        redirect_uri_provided_explicitly=data["redirect_uri_provided_explicitly"],
+        resource=data.get("resource"),
+    )
+
+
+def _pending_to_dict(pending: PendingConnectSession) -> dict[str, Any]:
+    return {
+        "client_id": pending.client_id,
+        "params": _params_to_dict(pending.params),
+        "connect_token": pending.connect_token,
+        "cartesia_credential": pending.cartesia_credential,
+        "cartesia_admin_credential": pending.cartesia_admin_credential,
+        "completing_owner_id": pending.completing_owner_id,
+        "completing_user_id": pending.completing_user_id,
+        "created_at": pending.created_at,
+    }
+
+
+def _pending_from_dict(data: dict[str, Any]) -> PendingConnectSession:
+    return PendingConnectSession(
+        client_id=data["client_id"],
+        params=_params_from_dict(data["params"]),
+        connect_token=data["connect_token"],
+        cartesia_credential=data.get("cartesia_credential"),
+        cartesia_admin_credential=data.get("cartesia_admin_credential"),
+        completing_owner_id=data.get("completing_owner_id"),
+        completing_user_id=data.get("completing_user_id"),
+        created_at=float(data.get("created_at") or time.time()),
+    )
+
+
+def _access_to_dict(stored: StoredMcpAccessToken) -> dict[str, Any]:
+    return {
+        "token": stored.token,
+        "cartesia_credential": stored.cartesia_credential,
+        "client_id": stored.client_id,
+        "scopes": list(stored.scopes),
+        "expires_at": stored.expires_at,
+        "cartesia_admin_credential": stored.cartesia_admin_credential,
+        "refresh_token": stored.refresh_token,
+    }
+
+
+def _access_from_dict(data: dict[str, Any]) -> StoredMcpAccessToken:
+    return StoredMcpAccessToken(
+        token=data["token"],
+        cartesia_credential=data["cartesia_credential"],
+        client_id=data["client_id"],
+        scopes=list(data.get("scopes") or []),
+        expires_at=int(data["expires_at"]),
+        cartesia_admin_credential=data.get("cartesia_admin_credential"),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _refresh_to_dict(stored: StoredMcpRefreshToken) -> dict[str, Any]:
+    return {
+        "token": stored.token,
+        "cartesia_credential": stored.cartesia_credential,
+        "client_id": stored.client_id,
+        "scopes": list(stored.scopes),
+        "expires_at": stored.expires_at,
+        "cartesia_admin_credential": stored.cartesia_admin_credential,
+        "access_token": stored.access_token,
+    }
+
+
+def _refresh_from_dict(data: dict[str, Any]) -> StoredMcpRefreshToken:
+    return StoredMcpRefreshToken(
+        token=data["token"],
+        cartesia_credential=data["cartesia_credential"],
+        client_id=data["client_id"],
+        scopes=list(data.get("scopes") or []),
+        expires_at=int(data["expires_at"]),
+        cartesia_admin_credential=data.get("cartesia_admin_credential"),
+        access_token=data.get("access_token"),
+    )
+
+
+def _auth_code_to_dict(auth_code: AuthorizationCode) -> dict[str, Any]:
+    return {
+        "code": auth_code.code,
+        "scopes": list(auth_code.scopes),
+        "expires_at": auth_code.expires_at,
+        "client_id": auth_code.client_id,
+        "code_challenge": auth_code.code_challenge,
+        "redirect_uri": str(auth_code.redirect_uri),
+        "redirect_uri_provided_explicitly": auth_code.redirect_uri_provided_explicitly,
+        "resource": auth_code.resource,
+        "subject": auth_code.subject,
+    }
+
+
+def _auth_code_from_dict(data: dict[str, Any]) -> AuthorizationCode:
+    return AuthorizationCode(
+        code=data["code"],
+        scopes=list(data.get("scopes") or []),
+        expires_at=float(data["expires_at"]),
+        client_id=data["client_id"],
+        code_challenge=data["code_challenge"],
+        redirect_uri=AnyUrl(data["redirect_uri"]),
+        redirect_uri_provided_explicitly=data["redirect_uri_provided_explicitly"],
+        resource=data.get("resource"),
+        subject=data.get("subject"),
+    )
 
 
 class OAuthStore:
-    def __init__(self) -> None:
-        self._clients: dict[str, OAuthClientInformationFull] = {}
-        self._pending: dict[str, PendingConnectSession] = {}
-        self._completed_sessions: dict[str, PendingConnectSession] = {}
-        self._auth_codes: dict[str, AuthorizationCode] = {}
-        self._mcp_tokens: dict[str, StoredMcpAccessToken] = {}
+    def __init__(self, backend: StoreBackend | None = None) -> None:
+        self._backend: StoreBackend = backend or MemoryBackend()
+
+    def use_backend(self, backend: StoreBackend) -> None:
+        self._backend = backend
+
+    def clear(self) -> None:
+        self._backend.clear()
 
     def register_client(self, client: OAuthClientInformationFull) -> None:
-        self._clients[client.client_id] = client
+        self._backend.set_json(
+            f"{_KEY_CLIENT}{client.client_id}",
+            client.model_dump(mode="json"),
+        )
 
     def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        return self._clients.get(client_id)
+        data = self._backend.get_json(f"{_KEY_CLIENT}{client_id}")
+        if data is None:
+            return None
+        return OAuthClientInformationFull.model_validate(data)
 
     def create_pending_session(
         self,
@@ -54,10 +294,15 @@ class OAuthStore:
     ) -> tuple[str, str]:
         session_id = secrets.token_urlsafe(32)
         connect_token = secrets.token_urlsafe(32)
-        self._pending[session_id] = PendingConnectSession(
+        pending = PendingConnectSession(
             client_id=client_id,
             params=params,
             connect_token=connect_token,
+        )
+        self._backend.set_json(
+            f"{_KEY_PENDING}{session_id}",
+            _pending_to_dict(pending),
+            ttl_seconds=PENDING_SESSION_TTL_SECONDS,
         )
         return session_id, connect_token
 
@@ -66,12 +311,20 @@ class OAuthStore:
         session_id: str,
         connect_token: str,
     ) -> PendingConnectSession:
-        pending = self._pending.get(session_id)
-        if pending is None or not secrets.compare_digest(
-            pending.connect_token, connect_token
-        ):
+        data = self._backend.get_json(f"{_KEY_PENDING}{session_id}")
+        if data is None:
+            raise KeyError(f"Unknown MCP OAuth session: {session_id}")
+        pending = _pending_from_dict(data)
+        if not secrets.compare_digest(pending.connect_token, connect_token):
             raise KeyError(f"Unknown MCP OAuth session: {session_id}")
         return pending
+
+    def _save_pending(self, session_id: str, pending: PendingConnectSession) -> None:
+        self._backend.set_json(
+            f"{_KEY_PENDING}{session_id}",
+            _pending_to_dict(pending),
+            ttl_seconds=PENDING_SESSION_TTL_SECONDS,
+        )
 
     def attach_credential(
         self,
@@ -92,6 +345,7 @@ class OAuthStore:
             ):
                 if cartesia_admin_credential:
                     pending.cartesia_admin_credential = cartesia_admin_credential
+                    self._save_pending(session_id, pending)
                 return pending
             raise ValueError("MCP OAuth session already completed")
         if (
@@ -103,6 +357,7 @@ class OAuthStore:
         pending.completing_user_id = completing_user_id
         pending.cartesia_credential = cartesia_credential
         pending.cartesia_admin_credential = cartesia_admin_credential
+        self._save_pending(session_id, pending)
         return pending
 
     def remember_completed_session(
@@ -119,7 +374,11 @@ class OAuthStore:
             completing_owner_id,
             completing_user_id,
         )
-        self._completed_sessions[key] = pending
+        self._backend.set_json(
+            f"{_KEY_COMPLETED}{key}",
+            _pending_to_dict(pending),
+            ttl_seconds=COMPLETED_SESSION_TTL_SECONDS,
+        )
 
     def get_completed_session(
         self,
@@ -134,7 +393,10 @@ class OAuthStore:
             completing_owner_id,
             completing_user_id,
         )
-        return self._completed_sessions.get(key)
+        data = self._backend.get_json(f"{_KEY_COMPLETED}{key}")
+        if data is None:
+            return None
+        return _pending_from_dict(data)
 
     def _completed_redirect_key(
         self,
@@ -146,10 +408,11 @@ class OAuthStore:
         return f"{session_id}:{connect_token}:{completing_owner_id}:{completing_user_id}"
 
     def pop_pending(self, session_id: str) -> PendingConnectSession:
-        pending = self._pending.pop(session_id, None)
-        if pending is None:
+        data = self._backend.get_json(f"{_KEY_PENDING}{session_id}")
+        if data is None:
             raise KeyError(f"Unknown MCP OAuth session: {session_id}")
-        return pending
+        self._backend.delete(f"{_KEY_PENDING}{session_id}")
+        return _pending_from_dict(data)
 
     def issue_authorization_code(
         self,
@@ -163,21 +426,27 @@ class OAuthStore:
         auth_code = AuthorizationCode(
             code=code,
             scopes=list(params.scopes or []),
-            expires_at=time.time() + 600,
+            expires_at=time.time() + AUTH_CODE_TTL_SECONDS,
             client_id=client_id,
             code_challenge=params.code_challenge,
             redirect_uri=params.redirect_uri,
             redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
             resource=params.resource,
         )
-        self._auth_codes[code] = auth_code
-        self._mcp_tokens[f"code:{code}"] = StoredMcpAccessToken(
-            token=f"code:{code}",
-            cartesia_credential=cartesia_credential,
-            client_id=client_id,
-            scopes=list(params.scopes or []),
-            expires_at=int(time.time()) + 600,
-            cartesia_admin_credential=cartesia_admin_credential,
+        self._backend.set_json(
+            f"{_KEY_AUTH_CODE}{code}",
+            _auth_code_to_dict(auth_code),
+            ttl_seconds=AUTH_CODE_TTL_SECONDS,
+        )
+        self._backend.set_json(
+            f"{_KEY_CODE_CREDENTIALS}{code}",
+            {
+                "cartesia_credential": cartesia_credential,
+                "cartesia_admin_credential": cartesia_admin_credential,
+                "client_id": client_id,
+                "scopes": list(params.scopes or []),
+            },
+            ttl_seconds=AUTH_CODE_TTL_SECONDS,
         )
         return auth_code
 
@@ -186,47 +455,178 @@ class OAuthStore:
         client: OAuthClientInformationFull,
         authorization_code: str,
     ) -> AuthorizationCode | None:
-        stored = self._auth_codes.get(authorization_code)
-        if stored is None or stored.client_id != client.client_id:
+        data = self._backend.get_json(f"{_KEY_AUTH_CODE}{authorization_code}")
+        if data is None:
+            return None
+        stored = _auth_code_from_dict(data)
+        if stored.client_id != client.client_id:
             return None
         if stored.expires_at < time.time():
             return None
         return stored
+
+    def _issue_token_pair(
+        self,
+        *,
+        client_id: str,
+        scopes: list[str],
+        cartesia_credential: str,
+        cartesia_admin_credential: str | None,
+    ) -> OAuthToken:
+        access_token = secrets.token_urlsafe(32)
+        refresh_token = secrets.token_urlsafe(32)
+        now = int(time.time())
+        access_expires_at = now + ACCESS_TOKEN_TTL_SECONDS
+        refresh_expires_at = now + REFRESH_TOKEN_TTL_SECONDS
+
+        access = StoredMcpAccessToken(
+            token=access_token,
+            cartesia_credential=cartesia_credential,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=access_expires_at,
+            cartesia_admin_credential=cartesia_admin_credential,
+            refresh_token=refresh_token,
+        )
+        refresh = StoredMcpRefreshToken(
+            token=refresh_token,
+            cartesia_credential=cartesia_credential,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=refresh_expires_at,
+            cartesia_admin_credential=cartesia_admin_credential,
+            access_token=access_token,
+        )
+        self._backend.set_json(
+            f"{_KEY_ACCESS}{access_token}",
+            _access_to_dict(access),
+            ttl_seconds=ACCESS_TOKEN_TTL_SECONDS,
+        )
+        self._backend.set_json(
+            f"{_KEY_REFRESH}{refresh_token}",
+            _refresh_to_dict(refresh),
+            ttl_seconds=REFRESH_TOKEN_TTL_SECONDS,
+        )
+        return OAuthToken(
+            access_token=access_token,
+            token_type="Bearer",
+            expires_in=ACCESS_TOKEN_TTL_SECONDS,
+            scope=" ".join(scopes) if scopes else None,
+            refresh_token=refresh_token,
+        )
 
     def exchange_authorization_code(
         self,
         client: OAuthClientInformationFull,
         authorization_code: AuthorizationCode,
     ) -> OAuthToken:
-        stored = self._mcp_tokens.pop(f"code:{authorization_code.code}", None)
-        self._auth_codes.pop(authorization_code.code, None)
-        if stored is None:
+        creds = self._backend.get_json(f"{_KEY_CODE_CREDENTIALS}{authorization_code.code}")
+        self._backend.delete(f"{_KEY_AUTH_CODE}{authorization_code.code}")
+        self._backend.delete(f"{_KEY_CODE_CREDENTIALS}{authorization_code.code}")
+        if creds is None:
+            raise ValueError("Authorization code not found")
+        if creds.get("client_id") != client.client_id:
             raise ValueError("Authorization code not found")
 
-        access_token = secrets.token_urlsafe(32)
-        expires_at = int(time.time()) + 3600
-        self._mcp_tokens[access_token] = StoredMcpAccessToken(
-            token=access_token,
-            cartesia_credential=stored.cartesia_credential,
+        return self._issue_token_pair(
             client_id=client.client_id,
-            scopes=stored.scopes,
-            expires_at=expires_at,
-            cartesia_admin_credential=stored.cartesia_admin_credential,
-        )
-        return OAuthToken(
-            access_token=access_token,
-            token_type="Bearer",
-            expires_in=3600,
-            scope=" ".join(stored.scopes) if stored.scopes else None,
+            scopes=list(creds.get("scopes") or authorization_code.scopes or []),
+            cartesia_credential=creds["cartesia_credential"],
+            cartesia_admin_credential=creds.get("cartesia_admin_credential"),
         )
 
     def resolve_mcp_access_token(self, token: str) -> StoredMcpAccessToken | None:
-        stored = self._mcp_tokens.get(token)
-        if stored is None:
+        data = self._backend.get_json(f"{_KEY_ACCESS}{token}")
+        if data is None:
             return None
+        stored = _access_from_dict(data)
         if stored.expires_at < int(time.time()):
             return None
         return stored
+
+    def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        data = self._backend.get_json(f"{_KEY_REFRESH}{refresh_token}")
+        if data is None:
+            return None
+        stored = _refresh_from_dict(data)
+        if stored.client_id != client.client_id:
+            return None
+        if stored.expires_at < int(time.time()):
+            return None
+        return RefreshToken(
+            token=stored.token,
+            client_id=stored.client_id,
+            scopes=stored.scopes,
+            expires_at=stored.expires_at,
+        )
+
+    def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        data = self._backend.get_json(f"{_KEY_REFRESH}{refresh_token.token}")
+        if data is None:
+            raise ValueError("Refresh token not found")
+        stored = _refresh_from_dict(data)
+        if stored.client_id != client.client_id:
+            raise ValueError("Refresh token not found")
+        if stored.expires_at < int(time.time()):
+            raise ValueError("Refresh token expired")
+
+        requested_scopes = scopes or stored.scopes
+        if not set(requested_scopes).issubset(set(stored.scopes or requested_scopes)):
+            raise ValueError("Requested scopes exceed granted scopes")
+
+        if stored.access_token:
+            self._backend.delete(f"{_KEY_ACCESS}{stored.access_token}")
+        self._backend.delete(f"{_KEY_REFRESH}{refresh_token.token}")
+
+        return self._issue_token_pair(
+            client_id=client.client_id,
+            scopes=list(requested_scopes),
+            cartesia_credential=stored.cartesia_credential,
+            cartesia_admin_credential=stored.cartesia_admin_credential,
+        )
+
+    def revoke_token(self, token: str) -> None:
+        access = self._backend.get_json(f"{_KEY_ACCESS}{token}")
+        if access is not None:
+            stored = _access_from_dict(access)
+            self._backend.delete(f"{_KEY_ACCESS}{token}")
+            if stored.refresh_token:
+                self._backend.delete(f"{_KEY_REFRESH}{stored.refresh_token}")
+            return
+
+        refresh = self._backend.get_json(f"{_KEY_REFRESH}{token}")
+        if refresh is not None:
+            stored_refresh = _refresh_from_dict(refresh)
+            self._backend.delete(f"{_KEY_REFRESH}{token}")
+            if stored_refresh.access_token:
+                self._backend.delete(f"{_KEY_ACCESS}{stored_refresh.access_token}")
+
+
+def configure_oauth_store_from_env(
+    *,
+    hosted: bool,
+    redis_url: str | None,
+) -> OAuthStore:
+    """Configure the module singleton; fail closed when hosted without Redis."""
+    if hosted:
+        if not redis_url:
+            raise RuntimeError(
+                "REDIS_URL is required when MCP_HOSTED=1 "
+                "(hosted MCP OAuth state must persist across deploys)"
+            )
+        oauth_store.use_backend(RedisBackend(redis_url))
+    else:
+        oauth_store.use_backend(MemoryBackend())
+    return oauth_store
 
 
 oauth_store = OAuthStore()

--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -42,7 +42,12 @@ from cartesia_mcp.config import ensure_admin_client, env_or_none, validate_api_k
 from cartesia_mcp.clients import admin_client, client, require_admin_client
 from cartesia_mcp.credentials import configure_hosted_mode, configure_stdio_credentials
 from cartesia_mcp.fastmcp_server import CartesiaMCP
-from cartesia_mcp.hosted import fastmcp_hosted_kwargs, hosted_enabled, run_hosted
+from cartesia_mcp.hosted import (
+    configure_hosted_oauth_store,
+    fastmcp_hosted_kwargs,
+    hosted_enabled,
+    run_hosted,
+)
 from cartesia_mcp.request_options import sdk_kwargs_from_request_options
 from cartesia_mcp.utils import (
     create_output_file,
@@ -68,6 +73,8 @@ OUTPUT_DIRECTORY = os.getenv("OUTPUT_DIRECTORY", ".")
 
 if _is_hosted:
     configure_hosted_mode()
+    if hosted_enabled():
+        configure_hosted_oauth_store()
 elif CARTESIA_API_KEY:
     configure_stdio_credentials(CARTESIA_API_KEY, CARTESIA_ADMIN_API_KEY)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx>=0.28.1",
     "mcp[cli]>=1.27.0",
     "python-dotenv>=1.0.0",
+    "redis>=5.0.0",
     "uvicorn>=0.34.0",
 ]
 

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -1,29 +1,100 @@
-"""Tests for OAuth provider token loading."""
+"""Tests for OAuth provider token loading and refresh."""
 
 import asyncio
 
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
-from cartesia_mcp.oauth_store import StoredMcpAccessToken, oauth_store
+from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="test-client",
+        client_secret=None,
+        redirect_uris=[AnyUrl("cursor://callback")],
+        client_name="Test",
+        token_endpoint_auth_method="none",
+    )
+
+
+def _params() -> AuthorizationParams:
+    return AuthorizationParams(
+        state="s",
+        scopes=["mcp"],
+        code_challenge="challenge",
+        redirect_uri=AnyUrl("cursor://callback"),
+        redirect_uri_provided_explicitly=True,
+        resource=None,
+    )
+
+
+def _issue_tokens(provider: CartesiaOAuthProvider, client: OAuthClientInformationFull):
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = asyncio.run(
+        provider.load_authorization_code(
+            client,
+            redirect.split("code=")[1].split("&")[0],
+        )
+    )
+    assert auth_code is not None
+    return asyncio.run(provider.exchange_authorization_code(client, auth_code))
 
 
 def test_mcp_oauth_access_token_resolves_stored_credential():
-    oauth_store._mcp_tokens.clear()
-    mcp_token = "mcp_oauth_access_token_example"
-    oauth_store._mcp_tokens[mcp_token] = StoredMcpAccessToken(
-        token=mcp_token,
-        cartesia_credential="sk_car_oauth_test_key",
-        client_id="test-client",
-        scopes=["mcp"],
-        expires_at=9999999999,
-        cartesia_admin_credential="sk_car_admin_test.key",
-    )
-
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
     provider = CartesiaOAuthProvider(
         playground_url="https://play.cartesia.ai",
         mcp_server_url="https://mcp.cartesia.ai",
     )
-    access = asyncio.run(provider.load_access_token(mcp_token))
+    token = _issue_tokens(provider, client)
+    access = asyncio.run(provider.load_access_token(token.access_token))
 
     assert access is not None
     assert access.token == "sk_car_oauth_test_key"
     assert access.client_id == "test-client"
+
+
+def test_provider_refresh_grant_rotates_tokens():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    first = _issue_tokens(provider, client)
+    assert first.refresh_token
+
+    refresh = asyncio.run(provider.load_refresh_token(client, first.refresh_token))
+    assert refresh is not None
+    second = asyncio.run(
+        provider.exchange_refresh_token(client, refresh, scopes=["mcp"])
+    )
+    assert second.access_token != first.access_token
+    assert second.refresh_token != first.refresh_token
+
+    access = asyncio.run(provider.load_access_token(second.access_token))
+    assert access is not None
+    assert access.token == "sk_car_oauth_test_key"

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -98,3 +98,22 @@ def test_provider_refresh_grant_rotates_tokens():
     access = asyncio.run(provider.load_access_token(second.access_token))
     assert access is not None
     assert access.token == "sk_car_oauth_test_key"
+
+
+def test_provider_revoke_uses_opaque_mcp_bearer():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    issued = _issue_tokens(provider, client)
+    access = asyncio.run(provider.load_access_token(issued.access_token))
+    assert access is not None
+    assert access.token == "sk_car_oauth_test_key"
+    assert (access.claims or {}).get("mcp_access_token") == issued.access_token
+
+    asyncio.run(provider.revoke_token(access))
+    assert oauth_store.resolve_mcp_access_token(issued.access_token) is None
+    assert oauth_store.load_refresh_token(client, issued.refresh_token or "") is None

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -1,12 +1,22 @@
-"""Tests for OAuth store authorization code exchange."""
+"""Tests for OAuth store authorization code exchange and refresh."""
 
 from pydantic import AnyUrl
 import pytest
 
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
-from cartesia_mcp.oauth_store import oauth_store
+from cartesia_mcp.oauth_store import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    MemoryBackend,
+    configure_oauth_store_from_env,
+    oauth_store,
+)
 from mcp.server.auth.provider import AuthorizationParams
 from mcp.shared.auth import OAuthClientInformationFull
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
 
 
 def _client() -> OAuthClientInformationFull:
@@ -31,10 +41,7 @@ def _params() -> AuthorizationParams:
 
 
 def test_oauth_code_exchange_roundtrip():
-    oauth_store._clients.clear()
-    oauth_store._pending.clear()
-    oauth_store._auth_codes.clear()
-    oauth_store._mcp_tokens.clear()
+    _reset_store()
 
     client = _client()
     oauth_store.register_client(client)
@@ -65,17 +72,17 @@ def test_oauth_code_exchange_roundtrip():
 
     token = oauth_store.exchange_authorization_code(client, auth_code)
     assert token.access_token
+    assert token.refresh_token
+    assert token.expires_in == ACCESS_TOKEN_TTL_SECONDS
 
     loaded = oauth_store.resolve_mcp_access_token(token.access_token)
     assert loaded is not None
     assert loaded.cartesia_credential == "sk_car_oauth_test_key"
+    assert loaded.cartesia_admin_credential is None
 
 
 def test_oauth_admin_credential_propagates_to_access_token():
-    oauth_store._clients.clear()
-    oauth_store._pending.clear()
-    oauth_store._auth_codes.clear()
-    oauth_store._mcp_tokens.clear()
+    _reset_store()
 
     client = _client()
     oauth_store.register_client(client)
@@ -107,9 +114,53 @@ def test_oauth_admin_credential_propagates_to_access_token():
     assert loaded is not None
     assert loaded.cartesia_admin_credential == "sk_car_admin_test.key"
 
+    refresh = oauth_store.load_refresh_token(client, token.refresh_token or "")
+    assert refresh is not None
+    rotated = oauth_store.exchange_refresh_token(client, refresh, scopes=["mcp"])
+    loaded_after = oauth_store.resolve_mcp_access_token(rotated.access_token)
+    assert loaded_after is not None
+    assert loaded_after.cartesia_admin_credential == "sk_car_admin_test.key"
+
+
+def test_refresh_token_rotation_revokes_previous_tokens():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code_value = redirect.split("code=")[1].split("&")[0]
+    auth_code = oauth_store.load_authorization_code(client, auth_code_value)
+    assert auth_code is not None
+    first = oauth_store.exchange_authorization_code(client, auth_code)
+
+    refresh = oauth_store.load_refresh_token(client, first.refresh_token or "")
+    assert refresh is not None
+    second = oauth_store.exchange_refresh_token(client, refresh, scopes=[])
+
+    assert second.access_token != first.access_token
+    assert second.refresh_token != first.refresh_token
+    assert oauth_store.resolve_mcp_access_token(first.access_token) is None
+    assert oauth_store.load_refresh_token(client, first.refresh_token or "") is None
+    assert oauth_store.resolve_mcp_access_token(second.access_token) is not None
+
 
 def test_connect_token_required():
-    oauth_store._pending.clear()
+    _reset_store()
     client = _client()
     session_id, connect_token = oauth_store.create_pending_session(
         client.client_id,
@@ -144,7 +195,7 @@ def test_connect_token_required():
 
 
 def test_attach_credential_is_idempotent_for_same_payload():
-    oauth_store._pending.clear()
+    _reset_store()
     client = _client()
     session_id, connect_token = oauth_store.create_pending_session(
         client.client_id,
@@ -167,11 +218,13 @@ def test_attach_credential_is_idempotent_for_same_payload():
         completing_user_id="user_test",
         cartesia_admin_credential="sk_car_admin_test.key",
     )
-    assert second is first
+    assert second.cartesia_credential == first.cartesia_credential
+    assert second.cartesia_admin_credential == first.cartesia_admin_credential
+    assert second.completing_owner_id == first.completing_owner_id
 
 
 def test_attach_credential_allows_admin_upgrade_on_retry():
-    oauth_store._pending.clear()
+    _reset_store()
     client = _client()
     session_id, connect_token = oauth_store.create_pending_session(
         client.client_id,
@@ -197,9 +250,7 @@ def test_attach_credential_allows_admin_upgrade_on_retry():
 
 
 def test_completed_session_retries_issue_fresh_code():
-    oauth_store._completed_sessions.clear()
-    oauth_store._auth_codes.clear()
-    oauth_store._mcp_tokens.clear()
+    _reset_store()
     client = _client()
     session_id, connect_token = oauth_store.create_pending_session(
         client.client_id,
@@ -236,3 +287,109 @@ def test_completed_session_retries_issue_fresh_code():
     )
     assert first != second
     assert "code=" in second
+
+
+def test_configure_hosted_requires_redis_url():
+    _reset_store()
+    with pytest.raises(RuntimeError, match="REDIS_URL is required"):
+        configure_oauth_store_from_env(hosted=True, redis_url=None)
+
+
+def test_redis_backend_json_roundtrip(monkeypatch):
+    """RedisBackend must survive JSON encode/decode of OAuth payloads."""
+    from cartesia_mcp.oauth_store import RedisBackend, OAuthStore
+
+    class _FakeRedis:
+        def __init__(self) -> None:
+            self._data: dict[str, str] = {}
+
+        def ping(self) -> bool:
+            return True
+
+        def get(self, key: str) -> str | None:
+            return self._data.get(key)
+
+        def set(self, key: str, value: str) -> None:
+            self._data[key] = value
+
+        def setex(self, key: str, ttl: int, value: str) -> None:
+            self._data[key] = value
+
+        def delete(self, key: str) -> None:
+            self._data.pop(key, None)
+
+    fake = _FakeRedis()
+
+    class _FakeRedisModule:
+        @staticmethod
+        def from_url(*_args, **_kwargs):
+            return fake
+
+    monkeypatch.setitem(__import__("sys").modules, "redis", _FakeRedisModule)
+
+    store = OAuthStore(RedisBackend("redis://localhost:6379/0"))
+    client = _client()
+    store.register_client(client)
+    loaded_client = store.get_client(client.client_id)
+    assert loaded_client is not None
+    assert loaded_client.client_id == client.client_id
+
+    session_id, connect_token = store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+        cartesia_admin_credential="sk_car_admin_test.key",
+    )
+    pending = store.pop_pending(session_id)
+    auth_code = store.issue_authorization_code(
+        client_id=pending.client_id,
+        params=pending.params,
+        cartesia_credential=pending.cartesia_credential or "",
+        cartesia_admin_credential=pending.cartesia_admin_credential,
+    )
+    loaded_code = store.load_authorization_code(client, auth_code.code)
+    assert loaded_code is not None
+    token = store.exchange_authorization_code(client, loaded_code)
+    assert token.refresh_token
+    resolved = store.resolve_mcp_access_token(token.access_token)
+    assert resolved is not None
+    assert resolved.cartesia_credential == "sk_car_oauth_test_key"
+    assert resolved.cartesia_admin_credential == "sk_car_admin_test.key"
+
+
+def test_revoke_token_removes_access_and_refresh():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = oauth_store.load_authorization_code(
+        client,
+        redirect.split("code=")[1].split("&")[0],
+    )
+    assert auth_code is not None
+    token = oauth_store.exchange_authorization_code(client, auth_code)
+    oauth_store.revoke_token(token.access_token)
+    assert oauth_store.resolve_mcp_access_token(token.access_token) is None
+    assert oauth_store.load_refresh_token(client, token.refresh_token or "") is None

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -289,6 +289,73 @@ def test_completed_session_retries_issue_fresh_code():
     assert "code=" in second
 
 
+def test_authorization_code_is_single_use():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = oauth_store.load_authorization_code(
+        client,
+        redirect.split("code=")[1].split("&")[0],
+    )
+    assert auth_code is not None
+    first = oauth_store.exchange_authorization_code(client, auth_code)
+    assert first.access_token
+    with pytest.raises(ValueError, match="Authorization code not found"):
+        oauth_store.exchange_authorization_code(client, auth_code)
+
+
+def test_refresh_token_is_single_use():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = oauth_store.load_authorization_code(
+        client,
+        redirect.split("code=")[1].split("&")[0],
+    )
+    assert auth_code is not None
+    first = oauth_store.exchange_authorization_code(client, auth_code)
+    refresh = oauth_store.load_refresh_token(client, first.refresh_token or "")
+    assert refresh is not None
+    second = oauth_store.exchange_refresh_token(client, refresh, scopes=[])
+    assert second.access_token
+    with pytest.raises(ValueError, match="Refresh token not found"):
+        oauth_store.exchange_refresh_token(client, refresh, scopes=[])
+
+
 def test_configure_hosted_requires_redis_url():
     _reset_store()
     with pytest.raises(RuntimeError, match="REDIS_URL is required"):
@@ -308,6 +375,9 @@ def test_redis_backend_json_roundtrip(monkeypatch):
 
         def get(self, key: str) -> str | None:
             return self._data.get(key)
+
+        def getdel(self, key: str) -> str | None:
+            return self._data.pop(key, None)
 
         def set(self, key: str, value: str) -> None:
             self._data[key] = value
@@ -361,6 +431,9 @@ def test_redis_backend_json_roundtrip(monkeypatch):
     assert resolved is not None
     assert resolved.cartesia_credential == "sk_car_oauth_test_key"
     assert resolved.cartesia_admin_credential == "sk_car_admin_test.key"
+
+    with pytest.raises(ValueError, match="Authorization code not found"):
+        store.exchange_authorization_code(client, loaded_code)
 
 
 def test_revoke_token_removes_access_and_refresh():

--- a/uv.lock
+++ b/uv.lock
@@ -73,13 +73,14 @@ websockets = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.9.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia", extra = ["websockets"] },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "uvicorn" },
 ]
 
@@ -94,6 +95,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
@@ -622,6 +624,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hosted MCP currently stores OAuth state in process memory and issues 1-hour access tokens with no refresh grant, so Cursor/Claude Code users are forced to reauth after expiry or deploys. This change issues rotating refresh tokens and backs OAuth state with Redis when `MCP_HOSTED=1`.

## Changes

- Back `OAuthStore` with pluggable memory/Redis backends (Redis required in hosted mode; fail closed without `REDIS_URL`)
- Issue `refresh_token` on authorization-code exchange; implement refresh load/exchange with rotation
- Keep Cartesia API + admin credentials mapped across refresh
- Access token TTL 24h; refresh token TTL 30 days
- Extend OAuth store/provider tests (including Redis JSON roundtrip)

## Test plan

- [x] `uv run pytest` (85 passed)
- [x] Live Redis roundtrip: code exchange → refresh rotation → new store instance still resolves tokens
- [ ] After Redis is attached on Render: connect from Cursor and Claude Code
- [ ] Wait past access expiry (or force short TTL in staging) and confirm tools work without browser reauth
- [ ] Redeploy `mcp.cartesia.ai` mid-session; existing tokens still work
- [ ] Admin connect path still works after refresh
- [ ] stdio `uvx cartesia-mcp` with `CARTESIA_API_KEY` unchanged

**Deploy order:** ship the product `render.yaml` Redis + `REDIS_URL` change before or with this image, otherwise hosted boot fails closed without Redis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication token lifecycle, credential storage in Redis, and hosted boot requirements—deploy must provision `REDIS_URL` before or with this release or hosted MCP will not start.
> 
> **Overview**
> **Hosted MCP OAuth** moves from in-process memory to a pluggable **memory / Redis** store. When `MCP_HOSTED=1`, **`REDIS_URL` is required** or startup fails closed via `configure_oauth_store_from_env`.
> 
> The store now issues **rotating refresh tokens** (24h access, 30d refresh), with **atomic single-use** code and refresh redemption (`pop_json` / GETDEL). **Cartesia API and admin credentials** stay mapped through refresh. The provider implements refresh load/exchange, stores the opaque MCP bearer in access **claims** for revocation, and revokes linked access/refresh pairs.
> 
> **CI** adds a Redis service and passes `REDIS_URL` into the Docker `/health` smoke test. **`redis`** is a new dependency; OAuth store/provider tests cover rotation, revoke, hosted-without-Redis, and a mocked Redis JSON roundtrip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5508ec9d12894318d70b3e7fc7ab9812e317c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->