### PR TITLE
fix: make MCP structured output schemas allow null optionals

### DIFF
--- a/cartesia_mcp/custom_types/pronunciation.py
+++ b/cartesia_mcp/custom_types/pronunciation.py
@@ -6,10 +6,16 @@ class PronunciationDictItemParams(typing.TypedDict):
     pronunciation: str
 
 
-class ListPronunciationDictsResult(typing.TypedDict, total=False):
+class ListPronunciationDictsResult(typing.TypedDict):
+    """Paginated pronunciation-dict list.
+
+    `next_page` must be nullable: FastMCP dumps unset optional TypedDict fields as
+    ``None``, and clients validate structured output against this schema.
+    """
+
     data: typing.List[typing.Any]
     has_more: bool
-    next_page: str
+    next_page: typing.NotRequired[str | None]
 
 
 class DeletePronunciationDictResult(typing.TypedDict):

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -6,18 +6,29 @@ class DeleteVoiceResult(typing.TypedDict):
 
 
 class GeneratedAudioResult(typing.TypedDict, total=False):
-    """TTS with save=true returns file_id and usually download_url; voice_change is local-only."""
+    """Audio delivery fields for `text_to_speech` / `voice_change`.
 
-    file_id: str
-    download_url: str
-    file_path: str
+    Fields are optional because paths differ (`save=false` is local-only;
+    `voice_change` never mints cloud links). Optional string fields must be
+    nullable: FastMCP dumps unset TypedDict keys as ``None``.
+    """
+
+    file_id: str | None
+    download_url: str | None
+    file_path: str | None
 
 
-class DownloadedFileResult(typing.TypedDict, total=False):
+class DownloadedFileResult(typing.TypedDict):
+    """Result of `download_file` / cloud file delivery.
+
+    `download_url` is omitted when link minting fails; it must be nullable so
+    FastMCP structured output still validates.
+    """
+
     file_id: str
     file_path: str
     filename: str
-    download_url: str
+    download_url: typing.NotRequired[str | None]
 
 
 class ListVoicesResult(typing.TypedDict):

--- a/cartesia_mcp/custom_types/tool_results.py
+++ b/cartesia_mcp/custom_types/tool_results.py
@@ -20,7 +20,15 @@ class DownloadedFileResult(typing.TypedDict, total=False):
     download_url: str
 
 
-class ListVoicesResult(typing.TypedDict, total=False):
+class ListVoicesResult(typing.TypedDict):
+    """Paginated voice list returned by `list_voices`.
+
+    `next_page` is omitted by the tool when there is no further page, but FastMCP's
+    structured-output dump fills optional TypedDict fields with ``None``. The field
+    must therefore be nullable in the JSON Schema or clients reject the last page
+    with ``None is not of type 'string'``.
+    """
+
     data: typing.List[typing.Any]
     has_more: bool
-    next_page: str
+    next_page: typing.NotRequired[str | None]

--- a/tests/test_list_voices_output_schema.py
+++ b/tests/test_list_voices_output_schema.py
@@ -1,0 +1,99 @@
+"""Regression: list_voices last-page structured output must accept null next_page."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import jsonschema
+from cartesia.types import Voice
+
+import cartesia_mcp.server as server
+
+
+def _list_voices_tool():
+    return next(t for t in server.mcp._tool_manager.list_tools() if t.name == "list_voices")
+
+
+def _list_voices_output_schema() -> dict:
+    tools = asyncio.run(server.mcp.list_tools())
+    tool = next(t for t in tools if t.name == "list_voices")
+    assert tool.outputSchema is not None
+    return tool.outputSchema
+
+
+def _structured_content_for(result: dict) -> dict:
+    """Mirror FastMCP FuncMetadata.convert_result structured dump path."""
+    tool = _list_voices_tool()
+    assert tool.fn_metadata.output_model is not None
+    validated = tool.fn_metadata.output_model.model_validate(result)
+    return validated.model_dump(mode="json", by_alias=True)
+
+
+def _voice(**overrides: object) -> Voice:
+    values = {
+        "id": "voice_abc",
+        "created_at": datetime.now(timezone.utc),
+        "description": "internal clone",
+        "is_owner": True,
+        "is_public": False,
+        "language": "en",
+        "name": "internal_texas_clone",
+        "country": None,
+        "gender": None,
+        "preview_file_url": None,
+    }
+    values.update(overrides)
+    return Voice(**values)  # type: ignore[arg-type]
+
+
+def test_list_voices_output_schema_allows_null_next_page() -> None:
+    schema = _list_voices_output_schema()
+    next_page_schema = schema["properties"]["next_page"]
+    assert {"type": "null"} in next_page_schema.get("anyOf", [])
+
+
+@patch("cartesia_mcp.server.client")
+def test_list_voices_last_page_structured_output_validates(mock_client: MagicMock) -> None:
+    """Final pages omit next_page; FastMCP dump fills it as null."""
+    schema = _list_voices_output_schema()
+    page = MagicMock()
+    page.data = [_voice()]
+    page.has_next_page = lambda: False
+    mock_client.voices.list.return_value = page
+
+    result = server.list_voices(q="texas", limit=10)
+
+    assert "next_page" not in result
+    structured = _structured_content_for(result)
+    assert structured["next_page"] is None
+    assert structured["data"][0]["gender"] is None
+    jsonschema.validate(instance=structured, schema=schema)
+
+
+@patch("cartesia_mcp.server.client")
+def test_list_voices_with_next_page_structured_output_validates(
+    mock_client: MagicMock,
+) -> None:
+    schema = _list_voices_output_schema()
+    page = MagicMock()
+    page.data = [
+        _voice(
+            id="voice_xyz",
+            description="catalog voice",
+            is_owner=False,
+            is_public=True,
+            name="Jolene - Warm Storyteller",
+            country="US",
+            gender="feminine",
+        )
+    ]
+    page.has_next_page = lambda: True
+    mock_client.voices.list.return_value = page
+
+    result = server.list_voices(gender="feminine", q="southern", limit=1)
+
+    assert result["next_page"] == "voice_xyz"
+    structured = _structured_content_for(result)
+    jsonschema.validate(instance=structured, schema=schema)

--- a/tests/test_output_schema_nullability.py
+++ b/tests/test_output_schema_nullability.py
@@ -1,0 +1,56 @@
+"""Fail CI if any tool output schema has default=null without allowing null.
+
+FastMCP converts optional TypedDict fields to Pydantic fields with default=None
+and dumps unset keys as null. Clients then validate structuredContent against
+outputSchema — so ``type: string, default: null`` hard-fails at runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import cartesia_mcp.server as server
+
+
+def _allows_null(schema: dict[str, Any]) -> bool:
+    if schema.get("type") == "null":
+        return True
+    for alt in schema.get("anyOf", []) + schema.get("oneOf", []):
+        if isinstance(alt, dict) and alt.get("type") == "null":
+            return True
+    return False
+
+
+def _bad_null_defaults(schema: dict[str, Any], path: str = "$") -> list[str]:
+    issues: list[str] = []
+    if not isinstance(schema, dict):
+        return issues
+
+    if "default" in schema and schema["default"] is None and not _allows_null(schema):
+        issues.append(f"{path}: default=null but type does not allow null ({schema.get('type')!r})")
+
+    for name, prop in schema.get("properties", {}).items():
+        if isinstance(prop, dict):
+            issues.extend(_bad_null_defaults(prop, f"{path}.{name}"))
+
+    items = schema.get("items")
+    if isinstance(items, dict):
+        issues.extend(_bad_null_defaults(items, f"{path}[]"))
+
+    for name, defn in schema.get("$defs", {}).items():
+        if isinstance(defn, dict):
+            issues.extend(_bad_null_defaults(defn, f"{path}.$defs.{name}"))
+
+    return issues
+
+
+def test_all_tool_output_schemas_allow_null_defaults() -> None:
+    tools = asyncio.run(server.mcp.list_tools())
+    failures: list[str] = []
+    for tool in tools:
+        if tool.outputSchema is None:
+            continue
+        for issue in _bad_null_defaults(tool.outputSchema):
+            failures.append(f"{tool.name}: {issue}")
+    assert failures == [], "Invalid output schemas:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary

MCP clients were hard-failing tool calls with `Output validation error: None is not of type 'string'`. Root cause is FastMCP’s structured-output path: optional TypedDict fields are dumped as `null`, but several tool `outputSchema`s declared those fields as non-nullable strings with `default: null`.

The first place this showed up was `list_voices` on the last page (`next_page`). The same pattern also affected `text_to_speech`, `voice_change`, and `download_file`.

## Changes

- Make `ListVoicesResult.next_page` / `ListPronunciationDictsResult.next_page` nullable
- Make optional fields on `GeneratedAudioResult` nullable (`text_to_speech`, `voice_change`)
- Make `DownloadedFileResult.download_url` nullable; keep `file_id` / `file_path` / `filename` required
- Add regression tests for `list_voices` last-page structured dump
- Add CI auditor (`test_output_schema_nullability.py`) that fails if any tool schema has `default: null` without allowing null

## Test plan

- [x] `pytest tests/test_output_schema_nullability.py tests/test_list_voices_output_schema.py`
- [x] Full suite (`92 passed`)
- [ ] In Cursor: `list_voices` with an empty/final page no longer errors
- [ ] In Cursor: `voice_change` / `text_to_speech(save=false)` still return structured output without validation errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only typing and test changes; no runtime API or auth logic modified.
> 
> **Overview**
> Fixes MCP client **output validation errors** on paginated tools (especially `list_voices` on the last page) when FastMCP serializes omitted optional TypedDict keys as `null` but the published JSON Schema still required strings.
> 
> **TypedDict / schema alignment:** `ListVoicesResult` and `ListPronunciationDictsResult` now treat `next_page` as `NotRequired[str | None]` and require `data` / `has_more` so schemas no longer advertise invalid `default: null` on non-nullable types. Related result types (`GeneratedAudioResult`, `DownloadedFileResult`) document and type optional string fields as nullable for the same FastMCP dump behavior.
> 
> **Tests:** Adds `test_list_voices_output_schema.py` to assert `next_page` allows null and that last-page vs mid-page structured output passes `jsonschema` validation (including null `gender`). Adds `test_output_schema_nullability.py` to fail CI if any tool `outputSchema` has `default: null` without a null type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8193789f1c1a531a48df6928b3c33de9c964d13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->