### PR TITLE
fix: correct localize_voice lanugages annotation

### DIFF
--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -408,7 +408,8 @@ def voice_change(
         description : str
             The description of the new localized voice.
 
-        language : SupportedLanguage
+        language : typing.Literal["en", "de", "es", "fr", "ja", "pt", "zh", "hi", "it", "ko", "nl", "pl", "ru", "sv", "tr", "ar", "he", "ta", "te", "th"]
+            The language that the new localized voice should speak.
 
         original_speaker_gender : Gender
 
@@ -421,7 +422,28 @@ def localize_voice(
     voice_id: str,
     name: str,
     description: str,
-    language: SupportedLanguage,
+    language: typing.Literal[
+        "en",
+        "de",
+        "es",
+        "fr",
+        "ja",
+        "pt",
+        "zh",
+        "hi",
+        "it",
+        "ko",
+        "nl",
+        "pl",
+        "ru",
+        "sv",
+        "tr",
+        "ar",
+        "he",
+        "ta",
+        "te",
+        "th",
+    ],
     original_speaker_gender: typing.Literal["male", "female"],
     dialect: typing.Optional[str] = None,
     request_options: typing.Optional[RequestOptions] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "cartesia[websockets]>=3.2.0,<4.0.0",
+    "cartesia[websockets]>=3.4.0,<4.0.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.27.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "cartesia"
-version = "3.2.0"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -61,9 +61,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/03/fcbb885bc08187d26791206ce67ac469ce1ae256b8f822609a32f1055084/cartesia-3.2.0.tar.gz", hash = "sha256:5d7f627b17c75ed216052d02ee27101a33753c34a8c2c3537217f2ee682b50ac", size = 333356, upload-time = "2026-05-28T05:26:04.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/8a/864a05a342f74aca4ee465a250fe38947ff1878c9e24504d38845d8c3b18/cartesia-3.4.0.tar.gz", hash = "sha256:318fc804c5a868426dec702507b03ff8f60ec93bb8602e92fd50cf05773eb10f", size = 335958, upload-time = "2026-07-21T22:00:22.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/46/56ab5977716823edad34cbe4f7238392ede3e8f0615352d412aae6d36d7d/cartesia-3.2.0-py3-none-any.whl", hash = "sha256:982d3cbfce4098318ba58bea13766572ed0b1bb1d4f88f3d025fd13baadcd26f", size = 210659, upload-time = "2026-05-28T05:26:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2d/fda58bb884884b5f966856139bccab18e800f7ad1d6a68c0b31161023908/cartesia-3.4.0-py3-none-any.whl", hash = "sha256:288e0cfacdf3aa7110ec2debf25fb6a7ea343f817c0ce00699507b6df02d9d12", size = 212694, upload-time = "2026-07-21T22:00:20.547Z" },
 ]
 
 [package.optional-dependencies]
@@ -73,7 +73,7 @@ websockets = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.15.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia", extra = ["websockets"] },
@@ -91,7 +91,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", extras = ["websockets"], specifier = ">=3.2.0,<4.0.0" },
+    { name = "cartesia", extras = ["websockets"], specifier = ">=3.4.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
This change does 2 things:

1. Reduces the set of voice localization languages to match what the SDK exposes. These are the stable languages that we expose in [our docs](https://docs.cartesia.ai/api-reference/voices/localize#body-language). This only affects the tool annotation so that agents won't try and use languages that are undocumented.
2. Upgrades to `cartesia>=3.4.0`, which adds a few more languages to the type hint (and also changes user agent headers).

Both of these are "cosmetic" changes only. The API does support the full set of TTS languages (except Norwegian + female I think) and the upgrade will not affect how requests are made or handled (for the most part).

Up for discussion: it could be fine to leave the annotation as `SupportedLanguage`, which is the full set of TTS languages. This only breaks in some edge cases, but largely should function. Results in unsupported localize languages are unclear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and dependency-only changes; runtime localize behavior is unchanged aside from the SDK minor bump.
> 
> **Overview**
> Aligns the **`localize_voice`** MCP tool with the documented voice-localization language set by replacing the broad `SupportedLanguage` type with an explicit `typing.Literal` of stable locale codes (matching the public localize API docs). That only changes the tool schema/description agents see, not the underlying `client.voices.localize` call path.
> 
> Bumps the **`cartesia[websockets]`** dependency from `>=3.2.0` to `>=3.4.0` and refreshes **`uv.lock`** accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ba2e1760e8f8f2a3845ee914154216e5e8aabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->