### PR TITLE
feat: use SDK localize language, gender, and dialect types

### DIFF
--- a/cartesia_mcp/server.py
+++ b/cartesia_mcp/server.py
@@ -11,8 +11,11 @@ from dotenv import load_dotenv
 from mcp.types import ToolAnnotations
 from cartesia import Cartesia, RequestOptions, omit
 from cartesia.types import (
+    Gender,
     GenderPresentation,
     GenerationConfigParam,
+    LocalizeDialect,
+    LocalizeTargetLanguage,
     OutputFormatContainer,
     RawEncoding,
     STTEncoding,
@@ -408,11 +411,13 @@ def voice_change(
         description : str
             The description of the new localized voice.
 
-        language : SupportedLanguage
+        language : LocalizeTargetLanguage
+            Target language to localize the voice to. Distinct from TTS SupportedLanguage.
 
         original_speaker_gender : Gender
 
-        dialect : typing.Optional[LocalizeDialectParams]
+        dialect : typing.Optional[LocalizeDialect]
+            Dialect allowlist for English, Spanish, Portuguese, and French.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -421,9 +426,9 @@ def localize_voice(
     voice_id: str,
     name: str,
     description: str,
-    language: SupportedLanguage,
-    original_speaker_gender: typing.Literal["male", "female"],
-    dialect: typing.Optional[str] = None,
+    language: LocalizeTargetLanguage,
+    original_speaker_gender: Gender,
+    dialect: typing.Optional[LocalizeDialect] = None,
     request_options: typing.Optional[RequestOptions] = None,
 ) -> VoiceMetadata:
     return client.voices.localize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    # Temporary: pin until cartesia 3.5.0+ on PyPI exports LocalizeTargetLanguage /
-    # Gender / LocalizeDialect. Direct URL works for both uv and pip (Docker).
-    "cartesia[websockets] @ git+https://github.com/cartesia-ai/cartesia-python.git@d435696fd1a9537054afaea59e67739c18510cb2",
+    "cartesia[websockets]>=3.5.0,<4.0.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.27.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,15 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "cartesia[websockets]>=3.4.0,<4.0.0",
+    # Temporary: pin until cartesia 3.5.0+ on PyPI exports LocalizeTargetLanguage /
+    # Gender / LocalizeDialect. Direct URL works for both uv and pip (Docker).
+    "cartesia[websockets] @ git+https://github.com/cartesia-ai/cartesia-python.git@d435696fd1a9537054afaea59e67739c18510cb2",
     "httpx>=0.28.1",
     "mcp[cli]>=1.27.0",
     "python-dotenv>=1.0.0",
     "redis>=5.0.0",
     "uvicorn>=0.34.0",
 ]
-
-# Temporary: resolve named localize/Emotion exports from the SDK PR branch until
-# those types ship on PyPI. Remove this override and raise the floor above once
-# cartesia exports LocalizeTargetLanguage / Gender / LocalizeDialect / Emotion.
-[tool.uv.sources]
-cartesia = { git = "https://github.com/cartesia-ai/cartesia-python", rev = "grant/sur-1468-named-localize-enums" }
 
 [project.scripts]
 cartesia-mcp = "cartesia_mcp.server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,19 @@ description = "The official Cartesia MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "cartesia[websockets]>=3.2.0,<4.0.0",
+    "cartesia[websockets]>=3.4.0,<4.0.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.27.0",
     "python-dotenv>=1.0.0",
     "redis>=5.0.0",
     "uvicorn>=0.34.0",
 ]
+
+# Temporary: resolve named localize/Emotion exports from the SDK PR branch until
+# those types ship on PyPI. Remove this override and raise the floor above once
+# cartesia exports LocalizeTargetLanguage / Gender / LocalizeDialect / Emotion.
+[tool.uv.sources]
+cartesia = { git = "https://github.com/cartesia-ai/cartesia-python", rev = "grant/sur-1468-named-localize-enums" }
 
 [project.scripts]
 cartesia-mcp = "cartesia_mcp.server:main"

--- a/uv.lock
+++ b/uv.lock
@@ -50,8 +50,8 @@ wheels = [
 
 [[package]]
 name = "cartesia"
-version = "3.4.0"
-source = { git = "https://github.com/cartesia-ai/cartesia-python.git?rev=d435696fd1a9537054afaea59e67739c18510cb2#d435696fd1a9537054afaea59e67739c18510cb2" }
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -60,6 +60,10 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "sniffio" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/87/5cd686fd51b28151f0c3a4efb9a8484c4c2a3cdc38e95da3ee90cb8a842a/cartesia-3.5.0.tar.gz", hash = "sha256:f653eb462efbc6883249fab764f53efd7f7356d5fe172bf8e4545f68fc3769b9", size = 336538, upload-time = "2026-07-23T20:32:50.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/e6/414b7b5df5dd51851ffbfabcdf9eec43fe2d82aa60e0e30a8501c7435d38/cartesia-3.5.0-py3-none-any.whl", hash = "sha256:ed06afce09f99c28e089e0732b0fb38ff9af52f114ee19f1a17e54dbdaa83251", size = 214111, upload-time = "2026-07-23T20:32:52.171Z" },
 ]
 
 [package.optional-dependencies]
@@ -87,7 +91,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", extras = ["websockets"], git = "https://github.com/cartesia-ai/cartesia-python.git?rev=d435696fd1a9537054afaea59e67739c18510cb2" },
+    { name = "cartesia", extras = ["websockets"], specifier = ">=3.5.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -50,8 +50,8 @@ wheels = [
 
 [[package]]
 name = "cartesia"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+version = "3.4.0"
+source = { git = "https://github.com/cartesia-ai/cartesia-python?rev=grant%2Fsur-1468-named-localize-enums#8b989f016087319ba6aaded3a4e8ac35f9eafc3e" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -61,10 +61,6 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/03/fcbb885bc08187d26791206ce67ac469ce1ae256b8f822609a32f1055084/cartesia-3.2.0.tar.gz", hash = "sha256:5d7f627b17c75ed216052d02ee27101a33753c34a8c2c3537217f2ee682b50ac", size = 333356, upload-time = "2026-05-28T05:26:04.493Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/46/56ab5977716823edad34cbe4f7238392ede3e8f0615352d412aae6d36d7d/cartesia-3.2.0-py3-none-any.whl", hash = "sha256:982d3cbfce4098318ba58bea13766572ed0b1bb1d4f88f3d025fd13baadcd26f", size = 210659, upload-time = "2026-05-28T05:26:05.707Z" },
-]
 
 [package.optional-dependencies]
 websockets = [
@@ -73,7 +69,7 @@ websockets = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.15.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia", extra = ["websockets"] },
@@ -91,7 +87,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", extras = ["websockets"], specifier = ">=3.2.0,<4.0.0" },
+    { name = "cartesia", extras = ["websockets"], git = "https://github.com/cartesia-ai/cartesia-python?rev=grant%2Fsur-1468-named-localize-enums" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 [[package]]
 name = "cartesia"
 version = "3.4.0"
-source = { git = "https://github.com/cartesia-ai/cartesia-python?rev=grant%2Fsur-1468-named-localize-enums#8b989f016087319ba6aaded3a4e8ac35f9eafc3e" }
+source = { git = "https://github.com/cartesia-ai/cartesia-python.git?rev=d435696fd1a9537054afaea59e67739c18510cb2#d435696fd1a9537054afaea59e67739c18510cb2" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -87,7 +87,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cartesia", extras = ["websockets"], git = "https://github.com/cartesia-ai/cartesia-python?rev=grant%2Fsur-1468-named-localize-enums" },
+    { name = "cartesia", extras = ["websockets"], git = "https://github.com/cartesia-ai/cartesia-python.git?rev=d435696fd1a9537054afaea59e67739c18510cb2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

Updates `localize_voice` to annotate against the Cartesia Python SDK localize allowlists (`LocalizeTargetLanguage`, `Gender`, `LocalizeDialect`) instead of TTS `SupportedLanguage` and inlined Literals. Agents get the correct localize language set in the tool schema.

Depends on Cartesia Python SDK **3.5.0+** on PyPI (now published).

## Changes

* Import and use `LocalizeTargetLanguage`, `Gender`, and `LocalizeDialect` on `localize_voice`
* Require `cartesia[websockets]>=3.5.0,<4.0.0` from PyPI

## Test plan

- [x] Tool annotation tests pass with cartesia 3.5.0 from PyPI
- [ ] Confirm MCP tool schema for `localize_voice.language` is the localize set (includes `ar`/`he`/`ta`/`te`/`th`, not full TTS list)
- [ ] Docker health check passes with the PyPI pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow typing and dependency bump on a single tool; no auth or core server logic changes, though agents may see a different enum set for `language`/`dialect`.
> 
> **Overview**
> Aligns the **`localize_voice`** MCP tool with Cartesia Python SDK **3.5.0+** so agents see the correct localize API in the tool schema.
> 
> **`language`** is now **`LocalizeTargetLanguage`** (localize allowlist) instead of TTS **`SupportedLanguage`**. **`original_speaker_gender`** uses SDK **`Gender`** instead of an inlined `"male"` / `"female"` literal. **`dialect`** is typed as optional **`LocalizeDialect`** instead of a plain string, with doc notes that it is the dialect allowlist for English, Spanish, Portuguese, and French.
> 
> The package pins **`cartesia[websockets]>=3.5.0,<4.0.0`** and **`uv.lock`** is updated accordingly; runtime behavior is still a pass-through to **`client.voices.localize`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec86f55241f294ea2cfe5eb38fa8dac86a9bb4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->