### PR TITLE
fix: restrict MCP OAuth redirect URIs to an allowlist

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -122,7 +122,10 @@ async def oauth_internal_complete(request: Request) -> Response:
         completing_user_id,
     )
     if completed is not None:
-        redirect_url = provider.build_resume_redirect(session_id, completed)
+        try:
+            redirect_url = provider.build_resume_redirect(session_id, completed)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
         return JSONResponse({"redirect_url": redirect_url})
 
     try:
@@ -134,12 +137,12 @@ async def oauth_internal_complete(request: Request) -> Response:
             completing_user_id=completing_user_id,
             cartesia_admin_credential=cartesia_admin_credential,
         )
+        redirect_url = provider.build_resume_redirect(session_id, pending)
     except KeyError:
         return JSONResponse({"error": "unknown_session"}, status_code=404)
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
 
-    redirect_url = provider.build_resume_redirect(session_id, pending)
     oauth_store.remember_completed_session(
         session_id,
         connect_token,

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import secrets
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from mcp.server.auth.provider import (
     AccessToken,
@@ -19,12 +19,60 @@ from pydantic import AnyUrl
 
 from cartesia_mcp.oauth_store import PendingConnectSession, oauth_store
 
-_ALLOWED_REDIRECT_SCHEMES = ("cursor:", "vscode:", "http:", "https:")
+# Native IDE / desktop MCP clients (custom URL schemes).
+_NATIVE_REDIRECT_SCHEMES = frozenset({"cursor", "vscode", "vscode-insiders"})
+
+# RFC 8252 loopback hosts (port may be ephemeral).
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# First-party HTTPS OAuth callbacks for known MCP hosts. Path must match exactly
+# unless listed with a trailing "/" as a prefix.
+_HTTPS_REDIRECT_EXACT = frozenset(
+    {
+        ("claude.ai", "/api/mcp/auth_callback"),
+        ("chatgpt.com", "/connector_platform_oauth_redirect"),
+    }
+)
+_HTTPS_REDIRECT_PREFIXES = (
+    ("chatgpt.com", "/connector/oauth/"),
+)
 
 
-def _redirect_uri_is_allowed(redirect_uri: AnyUrl) -> bool:
-    parsed = redirect_uri.unicode_string()
-    return parsed.startswith(_ALLOWED_REDIRECT_SCHEMES)
+def _redirect_uri_is_allowed(redirect_uri: AnyUrl | str) -> bool:
+    """Return True when a DCR / authorize redirect_uri is safe to use.
+
+    Open DCR is required for MCP clients, so the redirect URI is the security
+    boundary: reject arbitrary https hosts that would receive auth codes.
+    """
+    raw = (
+        redirect_uri.unicode_string()
+        if isinstance(redirect_uri, AnyUrl)
+        else str(redirect_uri)
+    )
+    parsed = urlparse(raw)
+    if parsed.username is not None or parsed.password is not None:
+        return False
+
+    scheme = parsed.scheme.lower()
+    if scheme in _NATIVE_REDIRECT_SCHEMES:
+        # Require a non-empty authority or path (reject bare "cursor:").
+        return bool(parsed.netloc or parsed.path)
+
+    host = (parsed.hostname or "").lower()
+    path = parsed.path or ""
+
+    if scheme == "http":
+        return host in _LOOPBACK_HOSTS
+
+    if scheme == "https":
+        if (host, path) in _HTTPS_REDIRECT_EXACT:
+            return True
+        return any(
+            host == allowed_host and path.startswith(prefix)
+            for allowed_host, prefix in _HTTPS_REDIRECT_PREFIXES
+        )
+
+    return False
 
 
 class CartesiaOAuthProvider(
@@ -46,7 +94,11 @@ class CartesiaOAuthProvider(
         if not all(_redirect_uri_is_allowed(uri) for uri in client_info.redirect_uris):
             raise RegistrationError(
                 error="invalid_client_metadata",
-                error_description="redirect_uris must use cursor, vscode, http, or https",
+                error_description=(
+                    "redirect_uris must be a native MCP client scheme "
+                    "(cursor/vscode), loopback http, or an allowlisted "
+                    "https callback"
+                ),
             )
         oauth_store.register_client(client_info)
 
@@ -55,6 +107,8 @@ class CartesiaOAuthProvider(
         client: OAuthClientInformationFull,
         params: AuthorizationParams,
     ) -> str:
+        if not _redirect_uri_is_allowed(params.redirect_uri):
+            raise ValueError("redirect_uri is not allowed")
         session_id, connect_token = oauth_store.create_pending_session(
             client.client_id,
             params,
@@ -142,6 +196,9 @@ class CartesiaOAuthProvider(
         session_id: str,
         pending: PendingConnectSession,
     ) -> str:
+        if not _redirect_uri_is_allowed(pending.params.redirect_uri):
+            # Block completions for clients registered before allowlisting.
+            raise ValueError("redirect_uri is not allowed")
         auth_code = oauth_store.issue_authorization_code(
             client_id=pending.client_id,
             params=pending.params,
@@ -163,6 +220,8 @@ def ensure_dynamic_client(client_id: str, redirect_uri: AnyUrl) -> OAuthClientIn
     existing = oauth_store.get_client(client_id)
     if existing is not None:
         return existing
+    if not _redirect_uri_is_allowed(redirect_uri):
+        raise ValueError("redirect_uri is not allowed")
     client = OAuthClientInformationFull(
         client_id=client_id,
         client_secret=None,
@@ -181,6 +240,8 @@ def register_ephemeral_client(redirect_uri: str | None = None) -> OAuthClientInf
         if redirect_uri
         else [AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback")]
     )
+    if not all(_redirect_uri_is_allowed(uri) for uri in redirect_uris):
+        raise ValueError("redirect_uri is not allowed")
     client = OAuthClientInformationFull(
         client_id=client_id,
         client_secret=None,

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -9,6 +9,7 @@ from mcp.server.auth.provider import (
     AccessToken,
     AuthorizationCode,
     AuthorizationParams,
+    AuthorizeError,
     OAuthAuthorizationServerProvider,
     RefreshToken,
     RegistrationError,
@@ -108,7 +109,10 @@ class CartesiaOAuthProvider(
         params: AuthorizationParams,
     ) -> str:
         if not _redirect_uri_is_allowed(params.redirect_uri):
-            raise ValueError("redirect_uri is not allowed")
+            raise AuthorizeError(
+                error="invalid_request",
+                error_description="redirect_uri is not allowed",
+            )
         session_id, connect_token = oauth_store.create_pending_session(
             client.client_id,
             params,

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -2,9 +2,13 @@
 
 import asyncio
 
-from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+import pytest
+from cartesia_mcp.oauth_provider import (
+    CartesiaOAuthProvider,
+    _redirect_uri_is_allowed,
+)
 from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
-from mcp.server.auth.provider import AuthorizationParams
+from mcp.server.auth.provider import AuthorizationParams, RegistrationError
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
@@ -12,6 +16,84 @@ from pydantic import AnyUrl
 def _reset_store() -> None:
     oauth_store.use_backend(MemoryBackend())
     oauth_store.clear()
+
+
+@pytest.mark.parametrize(
+    ("uri", "allowed"),
+    [
+        ("cursor://anysphere.cursor-mcp/oauth/callback", True),
+        ("vscode://vscode.github-authentication/oauth/callback", True),
+        ("vscode-insiders://callback", True),
+        ("http://127.0.0.1:58135/callback", True),
+        ("http://localhost:3118/callback", True),
+        ("http://[::1]:8080/callback", True),
+        ("https://claude.ai/api/mcp/auth_callback", True),
+        ("https://chatgpt.com/connector_platform_oauth_redirect", True),
+        ("https://chatgpt.com/connector/oauth/abc123", True),
+        ("https://evil.attacker.com/steal", False),
+        ("https://example.com/callback", False),
+        ("https://claude.ai/evil", False),
+        ("https://chatgpt.com/other", False),
+        ("javascript:alert(1)", False),
+        ("data:text/html,hi", False),
+        ("http://evil.com/callback", False),
+        ("https://user:pass@claude.ai/api/mcp/auth_callback", False),
+        ("cursor:", False),
+    ],
+)
+def test_redirect_uri_allowlist(uri: str, allowed: bool):
+    assert _redirect_uri_is_allowed(uri) is allowed
+
+
+def test_register_client_rejects_arbitrary_https_redirect():
+    _reset_store()
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    client = OAuthClientInformationFull(
+        client_id="evil-client",
+        client_secret=None,
+        redirect_uris=[AnyUrl("https://evil.attacker.com/steal")],
+        client_name="Evil",
+        token_endpoint_auth_method="none",
+    )
+    with pytest.raises(RegistrationError):
+        asyncio.run(provider.register_client(client))
+
+
+def test_build_resume_redirect_rejects_disallowed_uri():
+    _reset_store()
+    client = _client()
+    # Simulate a client registered before the allowlist existed.
+    client.redirect_uris = [AnyUrl("https://evil.attacker.com/steal")]
+    oauth_store.register_client(client)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        AuthorizationParams(
+            state="s",
+            scopes=["mcp"],
+            code_challenge="challenge",
+            redirect_uri=AnyUrl("https://evil.attacker.com/steal"),
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        ),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_test",
+        completing_user_id="user_test",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    with pytest.raises(ValueError, match="redirect_uri is not allowed"):
+        provider.build_resume_redirect(session_id, pending)
+
 
 
 def _client() -> OAuthClientInformationFull:

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -8,7 +8,11 @@ from cartesia_mcp.oauth_provider import (
     _redirect_uri_is_allowed,
 )
 from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
-from mcp.server.auth.provider import AuthorizationParams, RegistrationError
+from mcp.server.auth.provider import (
+    AuthorizationParams,
+    AuthorizeError,
+    RegistrationError,
+)
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
@@ -60,6 +64,33 @@ def test_register_client_rejects_arbitrary_https_redirect():
     )
     with pytest.raises(RegistrationError):
         asyncio.run(provider.register_client(client))
+
+
+def test_authorize_rejects_disallowed_redirect_with_authorize_error():
+    _reset_store()
+    client = _client()
+    # Client registered before allowlisting; authorize must still reject cleanly.
+    client.redirect_uris = [AnyUrl("https://evil.attacker.com/steal")]
+    oauth_store.register_client(client)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    with pytest.raises(AuthorizeError) as exc_info:
+        asyncio.run(
+            provider.authorize(
+                client,
+                AuthorizationParams(
+                    state="s",
+                    scopes=["mcp"],
+                    code_challenge="challenge",
+                    redirect_uri=AnyUrl("https://evil.attacker.com/steal"),
+                    redirect_uri_provided_explicitly=True,
+                    resource=None,
+                ),
+            )
+        )
+    assert exc_info.value.error == "invalid_request"
 
 
 def test_build_resume_redirect_rejects_disallowed_uri():


### PR DESCRIPTION
## Summary

Hosted MCP OAuth allows open Dynamic Client Registration. Registration previously accepted arbitrary `https://` redirect URIs, so an attacker could register a malicious callback, phish a user through the Connect flow, and exchange the auth code for an MCP token bound to the victim’s API key.

## Changes

- Allowlist DCR / authorize redirect URIs to native schemes (`cursor`, `vscode`, `vscode-insiders`), RFC 8252 loopback `http`, and known first-party HTTPS callbacks (Claude, ChatGPT)
- Reject redirect URIs that embed userinfo credentials
- Re-validate the redirect URI when building the post-Connect resume redirect so clients registered before this change cannot complete against a disallowed URI
- Add unit coverage for allow/deny cases, registration rejection, and resume-time enforcement

## Test plan

- [x] `uv run pytest tests/test_oauth_provider.py tests/test_oauth_store.py`
- [ ] After deploy: `POST /register` with `https://evil.example/callback` returns `invalid_client_metadata`
- [ ] After deploy: Cursor / Claude Code / Claude.ai hosted connect still completes
- [ ] After deploy: ChatGPT connector callback paths under `chatgpt.com` still register if used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth security boundaries and redirect validation on the auth/connect path; incorrect allowlisting could break legitimate MCP clients or leave a bypass for credential theft.
> 
> **Overview**
> **Tightens hosted MCP OAuth redirect handling** so open DCR can’t send authorization codes to arbitrary `https://` endpoints (a phishing / token theft vector).
> 
> `_redirect_uri_is_allowed` now parses URIs and only permits native IDE schemes (`cursor`, `vscode`, `vscode-insiders`), RFC 8252 loopback `http`, and specific first-party HTTPS callbacks (Claude.ai, ChatGPT connector paths). It rejects userinfo in URLs, bare custom schemes, and non-loopback `http`.
> 
> That check runs at **DCR**, **`authorize`** (via `AuthorizeError`), **`build_resume_redirect`** (blocks legacy registered clients), and in **`ensure_dynamic_client` / `register_ephemeral_client`**. The internal Connect completion route maps disallowed resume redirects to **400** JSON errors instead of returning a malicious URL.
> 
> Unit tests cover allow/deny matrix, registration rejection, authorize errors, and resume-time enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf0ed88449d88ca92df6e777a605c55172cffc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->