### PR TITLE
feat: expose pending OAuth session metadata for Connect UI

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -157,6 +157,34 @@ async def oauth_internal_complete(request: Request) -> Response:
     return JSONResponse({"redirect_url": redirect_url})
 
 
+async def oauth_internal_session(request: Request) -> Response:
+    """Return pending OAuth client_name + redirect_uri for the Connect UI."""
+    if not _authorized_internal(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    body = await request.json()
+    session_id = body.get("session_id")
+    connect_token = body.get("connect_token")
+    if not session_id or not connect_token:
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    from cartesia_mcp.oauth_store import oauth_store
+
+    try:
+        pending = oauth_store.get_pending_session(session_id, connect_token)
+    except KeyError:
+        return JSONResponse({"error": "unknown_session"}, status_code=404)
+
+    client = oauth_store.get_client(pending.client_id)
+    return JSONResponse(
+        {
+            "client_id": pending.client_id,
+            "client_name": client.client_name if client is not None else None,
+            "redirect_uri": str(pending.params.redirect_uri),
+        }
+    )
+
+
 def attach_hosted_routes(mcp: FastMCP) -> None:
     mcp._custom_starlette_routes.extend(
         [
@@ -164,6 +192,11 @@ def attach_hosted_routes(mcp: FastMCP) -> None:
             Route(
                 "/internal/oauth/complete",
                 endpoint=oauth_internal_complete,
+                methods=["POST"],
+            ),
+            Route(
+                "/internal/oauth/session",
+                endpoint=oauth_internal_session,
                 methods=["POST"],
             ),
         ]

--- a/tests/test_oauth_session_preview.py
+++ b/tests/test_oauth_session_preview.py
@@ -1,0 +1,90 @@
+"""Tests for internal OAuth session preview used by Connect UI."""
+
+from pydantic import AnyUrl
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from cartesia_mcp.hosted import oauth_internal_session
+from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
+
+
+def _client() -> TestClient:
+    app = Starlette(
+        routes=[
+            Route(
+                "/internal/oauth/session",
+                endpoint=oauth_internal_session,
+                methods=["POST"],
+            )
+        ]
+    )
+    return TestClient(app)
+
+
+def test_oauth_internal_session_returns_client_metadata(monkeypatch):
+    _reset_store()
+    monkeypatch.setenv("MCP_INTERNAL_SECRET", "test-secret")
+
+    client_info = OAuthClientInformationFull(
+        client_id="preview-client",
+        client_secret=None,
+        redirect_uris=[AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback")],
+        client_name="Cursor",
+        token_endpoint_auth_method="none",
+    )
+    oauth_store.register_client(client_info)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client_info.client_id,
+        AuthorizationParams(
+            state="s",
+            scopes=["mcp"],
+            code_challenge="challenge",
+            redirect_uri=AnyUrl("cursor://anysphere.cursor-mcp/oauth/callback"),
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        ),
+    )
+
+    response = _client().post(
+        "/internal/oauth/session",
+        headers={"Authorization": "Bearer test-secret"},
+        json={"session_id": session_id, "connect_token": connect_token},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "client_id": "preview-client",
+        "client_name": "Cursor",
+        "redirect_uri": "cursor://anysphere.cursor-mcp/oauth/callback",
+    }
+
+
+def test_oauth_internal_session_rejects_bad_token(monkeypatch):
+    _reset_store()
+    monkeypatch.setenv("MCP_INTERNAL_SECRET", "test-secret")
+
+    response = _client().post(
+        "/internal/oauth/session",
+        headers={"Authorization": "Bearer wrong"},
+        json={"session_id": "x", "connect_token": "y"},
+    )
+    assert response.status_code == 401
+
+
+def test_oauth_internal_session_unknown_session(monkeypatch):
+    _reset_store()
+    monkeypatch.setenv("MCP_INTERNAL_SECRET", "test-secret")
+
+    response = _client().post(
+        "/internal/oauth/session",
+        headers={"Authorization": "Bearer test-secret"},
+        json={"session_id": "missing", "connect_token": "missing"},
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

Adds an internal `POST /internal/oauth/session` endpoint that returns the pending OAuth `client_name` and `redirect_uri` for a Connect session (validated by session id + connect token). The playground uses this to show users where their authorization code will be sent.

## Changes

- Add `/internal/oauth/session` (Bearer `MCP_INTERNAL_SECRET`)
- Return `client_id`, `client_name`, and `redirect_uri` from the pending session
- Unit tests for success, unauthorized, and unknown session

## Test plan

- [ ] `uv run pytest tests/test_oauth_session_preview.py`
- [ ] After deploy, product Connect page can load session details (companion product PR)