### PR TITLE
feat: rate-limit MCP OAuth dynamic client registration

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -174,4 +174,16 @@ def run_hosted(mcp: FastMCP) -> None:
     if hosted_enabled():
         configure_hosted_oauth_store()
     attach_hosted_routes(mcp)
-    mcp.run(transport="streamable-http")
+
+    import uvicorn
+
+    from cartesia_mcp.register_rate_limit import RegisterRateLimitMiddleware
+
+    app = mcp.streamable_http_app()
+    app.add_middleware(RegisterRateLimitMiddleware)
+    uvicorn.run(
+        app,
+        host=mcp.settings.host,
+        port=mcp.settings.port,
+        log_level=mcp.settings.log_level.lower(),
+    )

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -25,6 +25,7 @@ _KEY_AUTH_CODE = "mcp:oauth:code:"
 _KEY_CODE_CREDENTIALS = "mcp:oauth:code-cred:"
 _KEY_ACCESS = "mcp:oauth:access:"
 _KEY_REFRESH = "mcp:oauth:refresh:"
+_KEY_REGISTER_RL = "mcp:oauth:register-rl:"
 
 
 @dataclass
@@ -74,6 +75,8 @@ class StoreBackend(Protocol):
         ttl_seconds: int | None = None,
     ) -> None: ...
 
+    def incr(self, key: str, *, ttl_seconds: int) -> int: ...
+
     def delete(self, key: str) -> None: ...
 
     def clear(self) -> None: ...
@@ -82,6 +85,7 @@ class StoreBackend(Protocol):
 class MemoryBackend:
     def __init__(self) -> None:
         self._data: dict[str, tuple[dict[str, Any], float | None]] = {}
+        self._counters: dict[str, tuple[int, float | None]] = {}
 
     def get_json(self, key: str) -> dict[str, Any] | None:
         entry = self._data.get(key)
@@ -112,11 +116,28 @@ class MemoryBackend:
         expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
         self._data[key] = (value, expires_at)
 
+    def incr(self, key: str, *, ttl_seconds: int) -> int:
+        now = time.time()
+        entry = self._counters.get(key)
+        if entry is not None:
+            count, expires_at = entry
+            if expires_at is not None and expires_at < now:
+                entry = None
+        if entry is None:
+            self._counters[key] = (1, now + ttl_seconds)
+            return 1
+        count, expires_at = entry
+        count += 1
+        self._counters[key] = (count, expires_at)
+        return count
+
     def delete(self, key: str) -> None:
         self._data.pop(key, None)
+        self._counters.pop(key, None)
 
     def clear(self) -> None:
         self._data.clear()
+        self._counters.clear()
 
 
 class RedisBackend:
@@ -151,6 +172,12 @@ class RedisBackend:
             self._redis.set(key, payload)
         else:
             self._redis.setex(key, ttl_seconds, payload)
+
+    def incr(self, key: str, *, ttl_seconds: int) -> int:
+        count = int(self._redis.incr(key))
+        if count == 1:
+            self._redis.expire(key, ttl_seconds)
+        return count
 
     def delete(self, key: str) -> None:
         self._redis.delete(key)
@@ -304,6 +331,18 @@ class OAuthStore:
         if data is None:
             return None
         return OAuthClientInformationFull.model_validate(data)
+
+    def increment_register_attempts(
+        self,
+        client_ip: str,
+        *,
+        window_seconds: int,
+    ) -> int:
+        """Increment and return the /register attempt count for an IP window."""
+        return self._backend.incr(
+            f"{_KEY_REGISTER_RL}{client_ip}",
+            ttl_seconds=window_seconds,
+        )
 
     def create_pending_session(
         self,

--- a/cartesia_mcp/register_rate_limit.py
+++ b/cartesia_mcp/register_rate_limit.py
@@ -1,0 +1,49 @@
+"""IP rate limiting for MCP OAuth Dynamic Client Registration."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from cartesia_mcp.oauth_store import oauth_store
+
+REGISTER_RATE_LIMIT = 30
+REGISTER_RATE_WINDOW_SECONDS = 60 * 60
+
+
+def client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",", 1)[0].strip()
+        if first:
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+class RegisterRateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.method == "POST" and request.url.path.rstrip("/") == "/register":
+            ip = client_ip(request)
+            count = oauth_store.increment_register_attempts(
+                ip,
+                window_seconds=REGISTER_RATE_WINDOW_SECONDS,
+            )
+            if count > REGISTER_RATE_LIMIT:
+                return JSONResponse(
+                    {
+                        "error": "too_many_requests",
+                        "error_description": (
+                            "Dynamic client registration rate limit exceeded"
+                        ),
+                    },
+                    status_code=429,
+                    headers={"Retry-After": str(REGISTER_RATE_WINDOW_SECONDS)},
+                )
+        return await call_next(request)

--- a/tests/test_register_rate_limit.py
+++ b/tests/test_register_rate_limit.py
@@ -1,0 +1,90 @@
+"""Tests for /register IP rate limiting."""
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
+from cartesia_mcp.register_rate_limit import (
+    REGISTER_RATE_LIMIT,
+    RegisterRateLimitMiddleware,
+    client_ip,
+)
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
+
+
+async def _ok_register(_: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+def _client() -> TestClient:
+    app = Starlette(routes=[Route("/register", endpoint=_ok_register, methods=["POST"])])
+    app.add_middleware(RegisterRateLimitMiddleware)
+    return TestClient(app)
+
+
+def test_client_ip_prefers_x_forwarded_for():
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [(b"x-forwarded-for", b"203.0.113.9, 10.0.0.1")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("test", 80),
+    }
+    request = Request(scope)
+    assert client_ip(request) == "203.0.113.9"
+
+
+def test_register_rate_limit_allows_under_cap():
+    _reset_store()
+    client = _client()
+    for _ in range(REGISTER_RATE_LIMIT):
+        response = client.post(
+            "/register",
+            headers={"x-forwarded-for": "198.51.100.2"},
+            json={},
+        )
+        assert response.status_code == 200
+
+
+def test_register_rate_limit_blocks_over_cap():
+    _reset_store()
+    client = _client()
+    for _ in range(REGISTER_RATE_LIMIT):
+        assert (
+            client.post(
+                "/register",
+                headers={"x-forwarded-for": "198.51.100.3"},
+                json={},
+            ).status_code
+            == 200
+        )
+
+    blocked = client.post(
+        "/register",
+        headers={"x-forwarded-for": "198.51.100.3"},
+        json={},
+    )
+    assert blocked.status_code == 429
+    assert blocked.json()["error"] == "too_many_requests"
+    assert blocked.headers["retry-after"]
+
+    # Different IP is unaffected.
+    other = client.post(
+        "/register",
+        headers={"x-forwarded-for": "198.51.100.4"},
+        json={},
+    )
+    assert other.status_code == 200


### PR DESCRIPTION
## Summary

Adds an IP-based rate limit on `POST /register` (30 requests / hour) so open Dynamic Client Registration cannot be used to flood the OAuth client registry.

## Changes

- Redis/memory-backed attempt counters keyed by client IP (`X-Forwarded-For` when present)
- Starlette middleware returns `429 too_many_requests` with `Retry-After` when exceeded
- Hosted server attaches the middleware around the Streamable HTTP app
- Unit tests for allow/block and IP extraction

## Test plan

- [ ] `uv run pytest tests/test_register_rate_limit.py`
- [ ] After deploy, burst `POST /register` from one IP and confirm 429 after the cap
- [ ] Confirm legitimate Cursor/Claude connect still registers within the limit