### PR TITLE
feat: expire idle MCP OAuth client registrations

### DIFF
--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -17,6 +17,8 @@ PENDING_SESSION_TTL_SECONDS = 600
 COMPLETED_SESSION_TTL_SECONDS = 600
 ACCESS_TOKEN_TTL_SECONDS = 24 * 60 * 60
 REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60
+# Idle DCR clients expire; authorize/token refresh extends the TTL.
+CLIENT_TTL_SECONDS = 90 * 24 * 60 * 60
 
 _KEY_CLIENT = "mcp:oauth:client:"
 _KEY_PENDING = "mcp:oauth:pending:"
@@ -74,6 +76,8 @@ class StoreBackend(Protocol):
         ttl_seconds: int | None = None,
     ) -> None: ...
 
+    def expire(self, key: str, ttl_seconds: int) -> None: ...
+
     def delete(self, key: str) -> None: ...
 
     def clear(self) -> None: ...
@@ -111,6 +115,13 @@ class MemoryBackend:
     ) -> None:
         expires_at = time.time() + ttl_seconds if ttl_seconds is not None else None
         self._data[key] = (value, expires_at)
+
+    def expire(self, key: str, ttl_seconds: int) -> None:
+        entry = self._data.get(key)
+        if entry is None:
+            return
+        value, _ = entry
+        self._data[key] = (value, time.time() + ttl_seconds)
 
     def delete(self, key: str) -> None:
         self._data.pop(key, None)
@@ -151,6 +162,9 @@ class RedisBackend:
             self._redis.set(key, payload)
         else:
             self._redis.setex(key, ttl_seconds, payload)
+
+    def expire(self, key: str, ttl_seconds: int) -> None:
+        self._redis.expire(key, ttl_seconds)
 
     def delete(self, key: str) -> None:
         self._redis.delete(key)
@@ -297,12 +311,16 @@ class OAuthStore:
         self._backend.set_json(
             f"{_KEY_CLIENT}{client.client_id}",
             client.model_dump(mode="json"),
+            ttl_seconds=CLIENT_TTL_SECONDS,
         )
 
     def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        data = self._backend.get_json(f"{_KEY_CLIENT}{client_id}")
+        key = f"{_KEY_CLIENT}{client_id}"
+        data = self._backend.get_json(key)
         if data is None:
             return None
+        # Refresh TTL on use so active clients are not evicted.
+        self._backend.expire(key, CLIENT_TTL_SECONDS)
         return OAuthClientInformationFull.model_validate(data)
 
     def create_pending_session(

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -6,6 +6,7 @@ import pytest
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
 from cartesia_mcp.oauth_store import (
     ACCESS_TOKEN_TTL_SECONDS,
+    CLIENT_TTL_SECONDS,
     MemoryBackend,
     configure_oauth_store_from_env,
     oauth_store,
@@ -362,6 +363,28 @@ def test_configure_hosted_requires_redis_url():
         configure_oauth_store_from_env(hosted=True, redis_url=None)
 
 
+def test_register_client_sets_ttl_and_get_refreshes():
+    backend = MemoryBackend()
+    oauth_store.use_backend(backend)
+    oauth_store.clear()
+
+    client = _client()
+    oauth_store.register_client(client)
+    key = f"mcp:oauth:client:{client.client_id}"
+    _, expires_at = backend._data[key]
+    assert expires_at is not None
+    assert expires_at > __import__("time").time() + CLIENT_TTL_SECONDS - 5
+
+    # Simulate an older expiry, then load to refresh.
+    value, _ = backend._data[key]
+    backend._data[key] = (value, __import__("time").time() + 60)
+    loaded = oauth_store.get_client(client.client_id)
+    assert loaded is not None
+    _, refreshed_expires_at = backend._data[key]
+    assert refreshed_expires_at is not None
+    assert refreshed_expires_at > __import__("time").time() + CLIENT_TTL_SECONDS - 5
+
+
 def test_redis_backend_json_roundtrip(monkeypatch):
     """RedisBackend must survive JSON encode/decode of OAuth payloads."""
     from cartesia_mcp.oauth_store import RedisBackend, OAuthStore
@@ -384,6 +407,9 @@ def test_redis_backend_json_roundtrip(monkeypatch):
 
         def setex(self, key: str, ttl: int, value: str) -> None:
             self._data[key] = value
+
+        def expire(self, key: str, ttl: int) -> bool:
+            return key in self._data
 
         def delete(self, key: str) -> None:
             self._data.pop(key, None)


### PR DESCRIPTION
## Summary

OAuth Dynamic Client Registration client records in Redis previously had no TTL, so abandoned (including pre-allowlist) registrations could live forever. New clients now expire after 90 days of inactivity, and successful client loads refresh the TTL.

## Changes

- Set a 90-day TTL when registering OAuth clients
- Refresh client key TTL on `get_client` (authorize/token paths)
- Add `expire` to the OAuth store backends
- Unit coverage for TTL set + refresh

## Test plan

- [ ] `uv run pytest tests/test_oauth_store.py`
- [ ] After deploy, inspect a new `mcp:oauth:client:*` key TTL in Redis
- [ ] Confirm a second authorize/token use refreshes TTL
- [ ] Confirm Cursor/Claude Connect still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client persistence and authorize/token paths; mis-TTL or missing refresh could break reconnects for idle clients, but behavior is additive with tests.
> 
> **Overview**
> **Dynamic Client Registration** records in the OAuth store no longer live forever in Redis. New registrations get a **90-day TTL**, and each successful **`get_client`** (authorize/token flows) **extends** that TTL so active integrations stay registered.
> 
> Store backends gain an **`expire`** helper (memory + Redis) to refresh key TTL without rewriting the payload. Tests cover registration TTL and refresh-on-load; the Redis test fake implements **`expire`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf146111ae51910bbfcacc29b6b1f3248395b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->