### PR TITLE
fix: allow Cursor, Claude.com, and VS Code Web OAuth redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ Some tools call [management endpoints](https://docs.cartesia.ai/api-reference/us
 
 Mint admin keys in the Playground under **Keys → Admin** (org admins only).
 
+### Hosted OAuth redirect URIs
+
+Hosted MCP (`mcp.cartesia.ai`) accepts Dynamic Client Registration with a restricted redirect-URI policy:
+
+- **Custom schemes** (desktop apps) — e.g. `cursor://…`, `vscode://…`
+- **Loopback HTTP** — `http://localhost|127.0.0.1|::1` (any port/path)
+- **Allowlisted HTTPS** — first-party callbacks for Claude, ChatGPT, Cursor web/Agents, and VS Code Web
+
+To temporarily allow another exact HTTPS callback without a code change, set:
+
+```text
+MCP_OAUTH_EXTRA_HTTPS_REDIRECTS=partner.example|/mcp/oauth/callback
+```
+
+(comma-separated `host|/path` pairs). Prefer adding durable hosts in code for known products.
+
 ### API version
 
 All tools send `Cartesia-Version` (default `2026-03-01`, the latest in [Cartesia docs](https://docs.cartesia.ai/use-the-api/api-conventions)). Override with `CARTESIA_VERSION` in `env` if you pin an older integration date.

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import secrets
 from urllib.parse import urlencode, urlparse
 
@@ -20,18 +21,38 @@ from pydantic import AnyUrl
 
 from cartesia_mcp.oauth_store import PendingConnectSession, oauth_store
 
-# Native IDE / desktop MCP clients (custom URL schemes).
-_NATIVE_REDIRECT_SCHEMES = frozenset({"cursor", "vscode", "vscode-insiders"})
+# Schemes that must never be treated as "native app" redirects.
+_BLOCKED_REDIRECT_SCHEMES = frozenset(
+    {
+        "http",
+        "https",
+        "javascript",
+        "data",
+        "file",
+        "blob",
+        "vbscript",
+        "about",
+    }
+)
 
 # RFC 8252 loopback hosts (port may be ephemeral).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 # First-party HTTPS OAuth callbacks for known MCP hosts. Path must match exactly
 # unless listed with a trailing "/" as a prefix.
+#
+# Desktop clients usually use loopback http or a custom scheme (allowed below).
+# Hosted web clients need an explicit HTTPS entry here (or via
+# MCP_OAUTH_EXTRA_HTTPS_REDIRECTS) — do not open arbitrary https:// hosts.
 _HTTPS_REDIRECT_EXACT = frozenset(
     {
         ("claude.ai", "/api/mcp/auth_callback"),
+        ("claude.com", "/api/mcp/auth_callback"),
         ("chatgpt.com", "/connector_platform_oauth_redirect"),
+        ("www.cursor.com", "/agents/mcp/oauth/callback"),
+        ("cursor.com", "/agents/mcp/oauth/callback"),
+        ("vscode.dev", "/redirect"),
+        ("insiders.vscode.dev", "/redirect"),
     }
 )
 _HTTPS_REDIRECT_PREFIXES = (
@@ -39,11 +60,38 @@ _HTTPS_REDIRECT_PREFIXES = (
 )
 
 
+def _extra_https_redirects_from_env() -> frozenset[tuple[str, str]]:
+    """Optional exact (host, path) pairs from MCP_OAUTH_EXTRA_HTTPS_REDIRECTS.
+
+    Format: comma-separated ``host|path`` entries, e.g.
+    ``example.com|/oauth/callback,www.example.com|/oauth/callback``.
+    """
+    raw = os.environ.get("MCP_OAUTH_EXTRA_HTTPS_REDIRECTS", "").strip()
+    if not raw:
+        return frozenset()
+    pairs: set[tuple[str, str]] = set()
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry or "|" not in entry:
+            continue
+        host, path = entry.split("|", 1)
+        host = host.strip().lower()
+        path = path.strip()
+        if host and path.startswith("/"):
+            pairs.add((host, path))
+    return frozenset(pairs)
+
+
 def _redirect_uri_is_allowed(redirect_uri: AnyUrl | str) -> bool:
     """Return True when a DCR / authorize redirect_uri is safe to use.
 
     Open DCR is required for MCP clients, so the redirect URI is the security
     boundary: reject arbitrary https hosts that would receive auth codes.
+
+    Allowed:
+    - Custom URI schemes (desktop IDEs), except blocked web/script schemes
+    - Loopback http (RFC 8252)
+    - Allowlisted first-party https callbacks (+ env extras)
     """
     raw = (
         redirect_uri.unicode_string()
@@ -55,7 +103,8 @@ def _redirect_uri_is_allowed(redirect_uri: AnyUrl | str) -> bool:
         return False
 
     scheme = parsed.scheme.lower()
-    if scheme in _NATIVE_REDIRECT_SCHEMES:
+    if scheme and scheme not in _BLOCKED_REDIRECT_SCHEMES:
+        # Native / private-use schemes (cursor://, windsurf://, …).
         # Require a non-empty authority or path (reject bare "cursor:").
         return bool(parsed.netloc or parsed.path)
 
@@ -66,7 +115,8 @@ def _redirect_uri_is_allowed(redirect_uri: AnyUrl | str) -> bool:
         return host in _LOOPBACK_HOSTS
 
     if scheme == "https":
-        if (host, path) in _HTTPS_REDIRECT_EXACT:
+        exact = _HTTPS_REDIRECT_EXACT | _extra_https_redirects_from_env()
+        if (host, path) in exact:
             return True
         return any(
             host == allowed_host and path.startswith(prefix)
@@ -96,9 +146,8 @@ class CartesiaOAuthProvider(
             raise RegistrationError(
                 error="invalid_client_metadata",
                 error_description=(
-                    "redirect_uris must be a native MCP client scheme "
-                    "(cursor/vscode), loopback http, or an allowlisted "
-                    "https callback"
+                    "redirect_uris must be a native app URI scheme, "
+                    "loopback http, or an allowlisted https callback"
                 ),
             )
         oauth_store.register_client(client_info)

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -28,18 +28,27 @@ def _reset_store() -> None:
         ("cursor://anysphere.cursor-mcp/oauth/callback", True),
         ("vscode://vscode.github-authentication/oauth/callback", True),
         ("vscode-insiders://callback", True),
+        ("windsurf://oauth/callback", True),
         ("http://127.0.0.1:58135/callback", True),
         ("http://localhost:3118/callback", True),
+        ("http://localhost:8787/callback", True),
         ("http://[::1]:8080/callback", True),
         ("https://claude.ai/api/mcp/auth_callback", True),
+        ("https://claude.com/api/mcp/auth_callback", True),
         ("https://chatgpt.com/connector_platform_oauth_redirect", True),
         ("https://chatgpt.com/connector/oauth/abc123", True),
+        ("https://www.cursor.com/agents/mcp/oauth/callback", True),
+        ("https://cursor.com/agents/mcp/oauth/callback", True),
+        ("https://vscode.dev/redirect", True),
+        ("https://insiders.vscode.dev/redirect", True),
         ("https://evil.attacker.com/steal", False),
         ("https://example.com/callback", False),
         ("https://claude.ai/evil", False),
         ("https://chatgpt.com/other", False),
+        ("https://www.cursor.com/evil", False),
         ("javascript:alert(1)", False),
         ("data:text/html,hi", False),
+        ("file:///etc/passwd", False),
         ("http://evil.com/callback", False),
         ("https://user:pass@claude.ai/api/mcp/auth_callback", False),
         ("cursor:", False),
@@ -47,6 +56,21 @@ def _reset_store() -> None:
 )
 def test_redirect_uri_allowlist(uri: str, allowed: bool):
     assert _redirect_uri_is_allowed(uri) is allowed
+
+
+def test_extra_https_redirects_from_env(monkeypatch):
+    monkeypatch.setenv(
+        "MCP_OAUTH_EXTRA_HTTPS_REDIRECTS",
+        "partner.example|/mcp/oauth/callback, bad-entry, missingpath|",
+    )
+    assert (
+        _redirect_uri_is_allowed("https://partner.example/mcp/oauth/callback") is True
+    )
+    assert _redirect_uri_is_allowed("https://partner.example/other") is False
+    monkeypatch.delenv("MCP_OAUTH_EXTRA_HTTPS_REDIRECTS", raising=False)
+    assert (
+        _redirect_uri_is_allowed("https://partner.example/mcp/oauth/callback") is False
+    )
 
 
 def test_register_client_rejects_arbitrary_https_redirect():


### PR DESCRIPTION
## Summary

Hosted MCP OAuth Dynamic Client Registration rejected Cursor’s current HTTPS callback (`https://www.cursor.com/agents/mcp/oauth/callback`), so Cursor → `mcp.cartesia.ai` connects failed even though loopback/`cursor://` alone would pass. This widens the allowlist for known first-party hosts and makes new desktop editors easier without opening arbitrary HTTPS.

## Changes

* Allow HTTPS callbacks for Cursor web/Agents, Claude.com, and VS Code Web (`vscode.dev` / Insiders)
* Accept any custom URI scheme except blocked web/script schemes (`javascript:`, `data:`, …) so new desktop IDEs work without a code change
* Add `MCP_OAUTH_EXTRA_HTTPS_REDIRECTS` (`host|/path` list) for temporary HTTPS allowlist entries
* Document the redirect policy in the README

## Test plan

- [x] `uv run pytest tests/test_oauth_provider.py`
- [ ] After deploy: Cursor desktop can connect to `https://mcp.cartesia.ai/mcp` via OAuth
- [ ] Confirm Claude.ai / ChatGPT still register successfully
- [ ] Confirm `https://evil.example/callback` still rejected