### PR TITLE
fix: offload sync MCP tools off the uvicorn event loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM python:3.13-slim
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV MCP_HOSTED=1
 ENV PORT=8000
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV PATH="/app/.venv/bin:$PATH"
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml uv.lock README.md ./
 COPY cartesia_mcp ./cartesia_mcp
 
-RUN pip install --no-cache-dir .
+RUN uv sync --frozen --no-dev --no-editable
 
 EXPOSE 8000
 

--- a/cartesia_mcp/fastmcp_server.py
+++ b/cartesia_mcp/fastmcp_server.py
@@ -2,13 +2,39 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
-from mcp.types import Tool as MCPTool
+from typing import Any
 
+from mcp.server.fastmcp import FastMCP
+from mcp.types import Icon, Tool as MCPTool, ToolAnnotations
+
+from cartesia_mcp.offload_sync import offload_sync_callable
 from cartesia_mcp.tool_visibility import is_tool_visible
 
 
 class CartesiaMCP(FastMCP):
+    def add_tool(
+        self,
+        fn: Any,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+    ) -> None:
+        # Sync SDK tools must not block uvicorn's event loop (Render /health).
+        super().add_tool(
+            offload_sync_callable(fn),
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+
     async def list_tools(self) -> list[MCPTool]:
         tools = await super().list_tools()
         return [tool for tool in tools if is_tool_visible(tool.name)]

--- a/cartesia_mcp/offload_sync.py
+++ b/cartesia_mcp/offload_sync.py
@@ -1,0 +1,40 @@
+"""Run sync MCP tool bodies off the asyncio event loop.
+
+Hosted streamable-http serves `/health` on the same uvicorn loop that executes
+tools. Sync Cartesia SDK calls can block that loop long enough for Render's 5s
+health timeout to fail and restart the instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def offload_sync_callable(fn: F) -> F:
+    """Wrap a sync callable so FastMCP awaits it via ``asyncio.to_thread``.
+
+    Contextvars are copied into the worker thread (Python 3.11+), so hosted
+    request-scoped API credentials remain available inside the tool body.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return fn
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    return cast(F, wrapper)
+
+
+def is_offloaded_sync_tool(fn: Callable[..., Any]) -> bool:
+    """True when ``fn`` is an async wrapper produced by :func:`offload_sync_callable`."""
+    if not inspect.iscoroutinefunction(fn):
+        return False
+    original = getattr(fn, "__wrapped__", None)
+    return original is not None and not inspect.iscoroutinefunction(original)

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import typing
+import uuid
 import wave
 from pathlib import Path
 
@@ -142,7 +143,10 @@ def create_output_file(output_directory: str, tool_type: ToolType,
         raise Exception(
             f"Output directory {dir_path} is not writable")
 
-    return dir_path / f"{tool_type}_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.{extension}"
+    # Include a uuid so concurrent offloaded tools in the same second don't
+    # collide on the same path.
+    stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    return dir_path / f"{tool_type}_{stamp}_{uuid.uuid4().hex[:8]}.{extension}"
 
 
 def cursor_page_to_result(page: SyncCursorIDPage[typing.Any]) -> dict[str, typing.Any]:

--- a/cartesia_mcp/utils.py
+++ b/cartesia_mcp/utils.py
@@ -120,12 +120,11 @@ def save_downloaded_file(
     if not Path(safe_name).suffix:
         safe_name = f"{safe_name}.bin"
 
-    output_path = dir_path / f"download_{safe_name}"
-    if output_path.exists():
-        stem = Path(safe_name).stem
-        suffix = Path(safe_name).suffix
-        ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        output_path = dir_path / f"download_{stem}_{ts}{suffix}"
+    # Always unique: concurrent offloaded download_file calls can race an
+    # exists-check + second-granularity timestamp.
+    stem = Path(safe_name).stem
+    suffix = Path(safe_name).suffix
+    output_path = dir_path / f"download_{stem}_{uuid.uuid4().hex[:8]}{suffix}"
 
     with output_path.open("wb") as f:
         f.write(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.13"
 dependencies = [
     "cartesia[websockets]>=3.5.0,<4.0.0",
     "httpx>=0.28.1",
-    "mcp[cli]>=1.27.0",
+    # mcp 2.0 removed mcp.server.fastmcp (renamed MCPServer). Stay on 1.x until we migrate.
+    "mcp[cli]>=1.27.0,<2",
     "python-dotenv>=1.0.0",
     "redis>=5.0.0",
     "uvicorn>=0.34.0",

--- a/tests/test_create_output_file.py
+++ b/tests/test_create_output_file.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 
-from cartesia_mcp.utils import create_output_file
+from cartesia_mcp.utils import create_output_file, save_downloaded_file
 
 
 def test_create_output_file_unique_under_concurrency(tmp_path):
@@ -19,3 +19,23 @@ def test_create_output_file_unique_under_concurrency(tmp_path):
         assert path.parent == tmp_path
         assert path.name.startswith("text_to_speech_")
         assert path.suffix == ".wav"
+
+
+def test_save_downloaded_file_unique_under_concurrency(tmp_path):
+    def _save(_: int):
+        return save_downloaded_file(
+            str(tmp_path),
+            file_id="file_abc",
+            filename="clip.wav",
+            content=b"audio",
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        paths = list(pool.map(_save, range(32)))
+
+    assert len({str(path) for path in paths}) == 32
+    for path in paths:
+        assert path.parent == tmp_path
+        assert path.name.startswith("download_clip_")
+        assert path.suffix == ".wav"
+        assert path.read_bytes() == b"audio"

--- a/tests/test_create_output_file.py
+++ b/tests/test_create_output_file.py
@@ -1,0 +1,21 @@
+"""Tests for local audio output path generation."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from cartesia_mcp.utils import create_output_file
+
+
+def test_create_output_file_unique_under_concurrency(tmp_path):
+    def _make_path(_: int):
+        return create_output_file(str(tmp_path), "text_to_speech", "wav")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        paths = list(pool.map(_make_path, range(32)))
+
+    assert len({str(path) for path in paths}) == 32
+    for path in paths:
+        assert path.parent == tmp_path
+        assert path.name.startswith("text_to_speech_")
+        assert path.suffix == ".wav"

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -255,7 +255,8 @@ def test_save_downloaded_file_uses_safe_filename(tmp_path) -> None:
     )
 
     assert output.parent == tmp_path
-    assert output.name == "download_name.wav"
+    assert output.name.startswith("download_name_")
+    assert output.suffix == ".wav"
     assert output.read_bytes() == b"data"
 
 
@@ -282,4 +283,4 @@ def test_save_downloaded_file_playback_pcm_saved_as_wav(tmp_path) -> None:
     )
 
     assert output.suffix == ".wav"
-    assert output.name == "download_generation.wav"
+    assert output.name.startswith("download_generation_")

--- a/tests/test_offload_sync.py
+++ b/tests/test_offload_sync.py
@@ -1,0 +1,124 @@
+"""Tests for offloading sync MCP tools off the uvicorn event loop."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import httpx
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from cartesia_mcp.fastmcp_server import CartesiaMCP
+from cartesia_mcp.offload_sync import is_offloaded_sync_tool, offload_sync_callable
+
+
+def test_offload_sync_callable_leaves_async_unchanged():
+    async def already_async() -> str:
+        return "ok"
+
+    assert offload_sync_callable(already_async) is already_async
+
+
+def test_offload_sync_callable_runs_in_worker_thread():
+    main_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def blocking() -> str:
+        seen["thread"] = threading.get_ident()
+        return "done"
+
+    wrapped = offload_sync_callable(blocking)
+    assert is_offloaded_sync_tool(wrapped)
+    assert asyncio.run(wrapped()) == "done"
+    assert seen["thread"] != main_thread
+
+
+def test_offload_sync_callable_preserves_contextvars():
+    from contextvars import ContextVar
+
+    token_var: ContextVar[str] = ContextVar("token_var")
+    token_var.set("hosted-key")
+
+    def read_token() -> str:
+        return token_var.get()
+
+    wrapped = offload_sync_callable(read_token)
+    assert asyncio.run(wrapped()) == "hosted-key"
+
+
+def test_cartesia_mcp_registers_sync_tools_as_offloaded():
+    mcp = CartesiaMCP("test-offload")
+
+    @mcp.tool()
+    def sleepy(seconds: float = 0.01) -> str:
+        time.sleep(seconds)
+        return "awake"
+
+    tool = mcp._tool_manager.get_tool("sleepy")
+    assert tool is not None
+    assert tool.is_async is True
+    assert is_offloaded_sync_tool(tool.fn)
+
+
+def test_health_stays_responsive_while_sync_tool_runs():
+    """Regression for Render health timeouts during long sync SDK tool calls."""
+
+    async def _run() -> None:
+        mcp = CartesiaMCP("test-health")
+        started = threading.Event()
+        release = threading.Event()
+
+        @mcp.tool()
+        def block_until_released() -> str:
+            started.set()
+            assert release.wait(timeout=5), "test timed out waiting for release"
+            return "ok"
+
+        async def health(_: Request) -> Response:
+            return JSONResponse({"status": "ok"})
+
+        app = Starlette(routes=[Route("/health", endpoint=health, methods=["GET"])])
+        tool = mcp._tool_manager.get_tool("block_until_released")
+        assert tool is not None
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            tool_task = asyncio.create_task(tool.run({}))
+            deadline = time.monotonic() + 2
+            while not started.is_set():
+                if time.monotonic() > deadline:
+                    raise AssertionError("tool never started")
+                await asyncio.sleep(0.01)
+
+            health_times: list[float] = []
+            for _ in range(5):
+                t0 = time.perf_counter()
+                response = await client.get("/health")
+                health_times.append(time.perf_counter() - t0)
+                assert response.status_code == 200
+                assert response.json() == {"status": "ok"}
+                await asyncio.sleep(0.05)
+
+            release.set()
+            result = await asyncio.wait_for(tool_task, timeout=2)
+
+        assert result == "ok"
+        # Health must not wait on the blocked sync tool (Render timeout is 5s).
+        assert max(health_times) < 0.5
+
+    asyncio.run(_run())
+
+
+def test_server_tools_are_offloaded_async():
+    import cartesia_mcp.server as server
+
+    tools = server.mcp._tool_manager.list_tools()
+    assert tools
+    for tool in tools:
+        assert tool.is_async, f"{tool.name} should be registered as async"
+        assert is_offloaded_sync_tool(tool.fn), f"{tool.name} should offload sync work"

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ websockets = [
 
 [[package]]
 name = "cartesia-mcp"
-version = "0.16.1"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "cartesia", extra = ["websockets"] },
@@ -93,7 +93,7 @@ dev = [
 requires-dist = [
     { name = "cartesia", extras = ["websockets"], specifier = ">=3.5.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },


### PR DESCRIPTION
## Summary

Hosted `mcp.cartesia.ai` runs sync Cartesia SDK tool handlers on uvicorn's single event loop. Long tools (especially `text_to_speech`) blocked `/health` long enough for Render's 5s health check to time out, restart the sole starter instance, and briefly 502 clients.

This wraps sync tools with `asyncio.to_thread` at registration time so `/health` stays responsive while SDK work runs.

## Changes

- Offload sync tool bodies via `asyncio.to_thread` in `CartesiaMCP.add_tool`
- Preserve contextvars so hosted request-scoped credentials still resolve in worker threads
- Add regression tests for off-loop execution and concurrent `/health` responsiveness

## Test plan

- [x] `uv run pytest` (136 passed)
- [ ] Deploy to Render and confirm `/health` keeps returning 200 during a long `text_to_speech` call
- [ ] Confirm no new health-check timeout alerts after deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every sync tool runs in production (thread pool) on the hosted path; behavior is regression-tested but deploy validation on Render during long TTS is still important.
> 
> **Overview**
> Fixes hosted **Render health-check restarts** by running sync Cartesia SDK tool bodies on worker threads instead of blocking uvicorn’s single event loop (where `/health` also runs).
> 
> **`CartesiaMCP.add_tool`** now wraps every sync handler with **`asyncio.to_thread`** via new **`offload_sync`**, while async tools are unchanged; contextvars are preserved so hosted request-scoped API keys still work in threads. Regression tests cover thread offload, contextvars, `/health` staying fast during a blocked tool, and that all server tools register as offloaded.
> 
> **Local output paths** in **`create_output_file`** and **`save_downloaded_file`** append a short **UUID** so concurrent offloaded writes no longer race on timestamp-based names; related tests and expectations were updated.
> 
> **Docker** installs deps with **`uv sync --frozen`** instead of **`pip install`**. **`mcp`** is capped at **`<2`** until a FastMCP 2.x migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f27d8673c9d14044613640e9aadea26e0ea6a2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->