### PR TITLE
feat: rate-limit hosted Streamable HTTP /mcp

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -228,9 +228,11 @@ def run_hosted(mcp: MCPServer) -> None:
 
     import uvicorn
 
+    from cartesia_mcp.mcp_rate_limit import McpRateLimitMiddleware
     from cartesia_mcp.register_rate_limit import RegisterRateLimitMiddleware
 
     app = mcp.streamable_http_app(**hosted_streamable_http_kwargs())
+    app.add_middleware(McpRateLimitMiddleware)
     app.add_middleware(RegisterRateLimitMiddleware)
     uvicorn.run(
         app,

--- a/cartesia_mcp/mcp_rate_limit.py
+++ b/cartesia_mcp/mcp_rate_limit.py
@@ -1,0 +1,61 @@
+"""Rate limiting for hosted Streamable HTTP /mcp."""
+
+from __future__ import annotations
+
+import hashlib
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from cartesia_mcp.oauth_store import oauth_store
+from cartesia_mcp.register_rate_limit import client_ip
+
+# Burst of ~60 in 10s covers initialize + tools/list + SSE; tens of rps reconnects trip it.
+MCP_RATE_LIMIT = 60
+MCP_RATE_WINDOW_SECONDS = 10
+
+
+def is_mcp_path(path: str) -> bool:
+    return path.rstrip("/") == "/mcp"
+
+
+def bearer_token(request: Request) -> str | None:
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:].strip()
+    return token or None
+
+
+def mcp_rate_limit_bucket(request: Request) -> str:
+    """Prefer a hashed bearer so shared egress IPs do not share one bucket."""
+    token = bearer_token(request)
+    if token is not None:
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+        return f"tok:{digest}"
+    return f"ip:{client_ip(request)}"
+
+
+class McpRateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.method in ("GET", "POST", "DELETE") and is_mcp_path(request.url.path):
+            bucket = mcp_rate_limit_bucket(request)
+            count = oauth_store.increment_mcp_attempts(
+                bucket,
+                window_seconds=MCP_RATE_WINDOW_SECONDS,
+            )
+            if count > MCP_RATE_LIMIT:
+                return JSONResponse(
+                    {
+                        "error": "too_many_requests",
+                        "error_description": "MCP request rate limit exceeded",
+                    },
+                    status_code=429,
+                    headers={"Retry-After": str(MCP_RATE_WINDOW_SECONDS)},
+                )
+        return await call_next(request)

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -28,6 +28,7 @@ _KEY_CODE_CREDENTIALS = "mcp:oauth:code-cred:"
 _KEY_ACCESS = "mcp:oauth:access:"
 _KEY_REFRESH = "mcp:oauth:refresh:"
 _KEY_REGISTER_RL = "mcp:oauth:register-rl:"
+_KEY_MCP_RL = "mcp:http:rl:"
 
 
 @dataclass
@@ -359,6 +360,18 @@ class OAuthStore:
         """Increment and return the /register attempt count for an IP window."""
         return self._backend.incr(
             f"{_KEY_REGISTER_RL}{client_ip}",
+            ttl_seconds=window_seconds,
+        )
+
+    def increment_mcp_attempts(
+        self,
+        bucket: str,
+        *,
+        window_seconds: int,
+    ) -> int:
+        """Increment and return the /mcp attempt count for a rate-limit bucket."""
+        return self._backend.incr(
+            f"{_KEY_MCP_RL}{bucket}",
             ttl_seconds=window_seconds,
         )
 

--- a/tests/test_mcp_rate_limit.py
+++ b/tests/test_mcp_rate_limit.py
@@ -1,0 +1,118 @@
+"""Tests for hosted /mcp rate limiting."""
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from cartesia_mcp.mcp_rate_limit import (
+    MCP_RATE_LIMIT,
+    McpRateLimitMiddleware,
+    mcp_rate_limit_bucket,
+)
+from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
+
+
+async def _ok_mcp(_: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+def _client() -> TestClient:
+    app = Starlette(
+        routes=[
+            Route("/mcp", endpoint=_ok_mcp, methods=["GET", "POST"]),
+            Route("/health", endpoint=_ok_mcp, methods=["GET"]),
+        ]
+    )
+    app.add_middleware(McpRateLimitMiddleware)
+    return TestClient(app)
+
+
+def test_mcp_rate_limit_bucket_prefers_bearer_hash():
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": "/mcp",
+        "raw_path": b"/mcp",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", b"Bearer secret-token"),
+            (b"x-forwarded-for", b"203.0.113.9"),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("test", 80),
+    }
+    bucket = mcp_rate_limit_bucket(Request(scope))
+    assert bucket.startswith("tok:")
+    assert "secret-token" not in bucket
+    assert "203.0.113.9" not in bucket
+
+
+def test_mcp_rate_limit_allows_under_cap():
+    _reset_store()
+    client = _client()
+    for _ in range(MCP_RATE_LIMIT):
+        response = client.post(
+            "/mcp",
+            headers={
+                "authorization": "Bearer tok-a",
+                "x-forwarded-for": "198.51.100.2",
+            },
+            json={},
+        )
+        assert response.status_code == 200
+
+
+def test_mcp_rate_limit_blocks_over_cap():
+    _reset_store()
+    client = _client()
+    headers = {
+        "authorization": "Bearer tok-b",
+        "x-forwarded-for": "198.51.100.3",
+    }
+    for _ in range(MCP_RATE_LIMIT):
+        assert client.post("/mcp", headers=headers, json={}).status_code == 200
+
+    blocked = client.post("/mcp", headers=headers, json={})
+    assert blocked.status_code == 429
+    assert blocked.json()["error"] == "too_many_requests"
+    assert blocked.headers["retry-after"] == "10"
+
+    other = client.post(
+        "/mcp",
+        headers={
+            "authorization": "Bearer tok-c",
+            "x-forwarded-for": "198.51.100.3",
+        },
+        json={},
+    )
+    assert other.status_code == 200
+
+
+def test_mcp_rate_limit_unauthenticated_keys_by_ip():
+    _reset_store()
+    client = _client()
+    shared = {"x-forwarded-for": "198.51.100.6"}
+    for _ in range(MCP_RATE_LIMIT):
+        assert client.get("/mcp", headers=shared).status_code == 200
+
+    assert client.get("/mcp", headers=shared).status_code == 429
+    other = client.get("/mcp", headers={"x-forwarded-for": "198.51.100.7"})
+    assert other.status_code == 200
+
+
+def test_mcp_rate_limit_skips_health():
+    _reset_store()
+    client = _client()
+    headers = {"x-forwarded-for": "198.51.100.5"}
+    for _ in range(MCP_RATE_LIMIT + 5):
+        assert client.get("/health", headers=headers).status_code == 200


### PR DESCRIPTION
## Summary

Hosted `/mcp` had no request cap, so a Streamable HTTP reconnect loop could 502 the single Render instance. `/register` was already limited; this applies a Redis window to GET/POST/DELETE `/mcp`.

A normal initialize + tools/list + SSE burst stays under the cap. Tens of requests per second trip 429 with `Retry-After`.

## Changes

- Redis counter per hashed bearer token (fallback: client IP from `X-Forwarded-For`)
- 60 requests / 10 seconds; `/health` is not limited
- 429 JSON `too_many_requests` plus `Retry-After: 10`

## Test plan

- [x] `uv run pytest`
- [ ] After deploy, a single Cursor MCP session still connects
- [ ] Rapid POST `/mcp` from one token returns 429
- [ ] A second token on the same IP is not blocked by the first