### PR TITLE
feat: log owner and JSON-RPC method on hosted /mcp

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -235,10 +235,12 @@ def run_hosted(mcp: MCPServer) -> None:
     import uvicorn
 
     from cartesia_mcp.mcp_rate_limit import McpRateLimitMiddleware
+    from cartesia_mcp.mcp_request_log import McpRequestLogMiddleware
     from cartesia_mcp.register_rate_limit import RegisterRateLimitMiddleware
 
     app = mcp.streamable_http_app(**hosted_streamable_http_kwargs())
     app.add_middleware(McpRateLimitMiddleware)
+    app.add_middleware(McpRequestLogMiddleware)
     app.add_middleware(RegisterRateLimitMiddleware)
     uvicorn.run(
         app,

--- a/cartesia_mcp/mcp_request_log.py
+++ b/cartesia_mcp/mcp_request_log.py
@@ -1,0 +1,90 @@
+"""Log org/user/client and JSON-RPC method for hosted /mcp requests."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from cartesia_mcp.credentials import looks_like_cartesia_api_key
+from cartesia_mcp.mcp_rate_limit import bearer_token, is_mcp_path
+from cartesia_mcp.oauth_store import oauth_store
+
+logger = logging.getLogger("cartesia_mcp.mcp")
+
+_MAX_RPC_METHOD_LEN = 64
+
+
+@dataclass(frozen=True)
+class McpRequestIdentity:
+    owner_id: str | None = None
+    user_id: str | None = None
+    client_name: str | None = None
+    auth: str | None = None
+
+
+def jsonrpc_method_from_body(body: bytes) -> str | None:
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    method: object = None
+    if isinstance(payload, dict):
+        method = payload.get("method")
+    elif isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        method = payload[0].get("method")
+    if not isinstance(method, str) or not method or len(method) > _MAX_RPC_METHOD_LEN:
+        return None
+    return method
+
+
+def mcp_request_identity(request: Request) -> McpRequestIdentity:
+    token = bearer_token(request)
+    if token is None:
+        return McpRequestIdentity()
+    stored = oauth_store.resolve_mcp_access_token(token)
+    if stored is not None:
+        client = oauth_store.get_client(stored.client_id)
+        return McpRequestIdentity(
+            owner_id=stored.owner_id,
+            user_id=stored.user_id,
+            client_name=client.client_name if client is not None else None,
+            auth="oauth",
+        )
+    if looks_like_cartesia_api_key(token):
+        return McpRequestIdentity(auth="api_key")
+    return McpRequestIdentity()
+
+
+class McpRequestLogMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not is_mcp_path(request.url.path):
+            return await call_next(request)
+
+        rpc_method: str | None = None
+        if request.method == "POST":
+            rpc_method = jsonrpc_method_from_body(await request.body())
+        identity = mcp_request_identity(request)
+        response = await call_next(request)
+        logger.info(
+            "mcp request method=%s rpc=%s owner_id=%s user_id=%s "
+            "client_name=%s auth=%s status=%s",
+            request.method,
+            rpc_method or "-",
+            identity.owner_id or "-",
+            identity.user_id or "-",
+            identity.client_name or "-",
+            identity.auth or "-",
+            response.status_code,
+        )
+        return response

--- a/cartesia_mcp/oauth_provider.py
+++ b/cartesia_mcp/oauth_provider.py
@@ -257,6 +257,8 @@ class CartesiaOAuthProvider(
             params=pending.params,
             cartesia_credential=pending.cartesia_credential or "",
             cartesia_admin_credential=pending.cartesia_admin_credential,
+            completing_owner_id=pending.completing_owner_id,
+            completing_user_id=pending.completing_user_id,
         )
         query = urlencode(
             {

--- a/cartesia_mcp/oauth_store.py
+++ b/cartesia_mcp/oauth_store.py
@@ -52,6 +52,8 @@ class StoredMcpAccessToken:
     expires_at: int
     cartesia_admin_credential: str | None = None
     refresh_token: str | None = None
+    owner_id: str | None = None
+    user_id: str | None = None
 
 
 @dataclass
@@ -63,6 +65,8 @@ class StoredMcpRefreshToken:
     expires_at: int
     cartesia_admin_credential: str | None = None
     access_token: str | None = None
+    owner_id: str | None = None
+    user_id: str | None = None
 
 
 class StoreBackend(Protocol):
@@ -258,6 +262,8 @@ def _access_to_dict(stored: StoredMcpAccessToken) -> dict[str, Any]:
         "expires_at": stored.expires_at,
         "cartesia_admin_credential": stored.cartesia_admin_credential,
         "refresh_token": stored.refresh_token,
+        "owner_id": stored.owner_id,
+        "user_id": stored.user_id,
     }
 
 
@@ -270,6 +276,8 @@ def _access_from_dict(data: dict[str, Any]) -> StoredMcpAccessToken:
         expires_at=int(data["expires_at"]),
         cartesia_admin_credential=data.get("cartesia_admin_credential"),
         refresh_token=data.get("refresh_token"),
+        owner_id=data.get("owner_id"),
+        user_id=data.get("user_id"),
     )
 
 
@@ -282,6 +290,8 @@ def _refresh_to_dict(stored: StoredMcpRefreshToken) -> dict[str, Any]:
         "expires_at": stored.expires_at,
         "cartesia_admin_credential": stored.cartesia_admin_credential,
         "access_token": stored.access_token,
+        "owner_id": stored.owner_id,
+        "user_id": stored.user_id,
     }
 
 
@@ -294,6 +304,8 @@ def _refresh_from_dict(data: dict[str, Any]) -> StoredMcpRefreshToken:
         expires_at=int(data["expires_at"]),
         cartesia_admin_credential=data.get("cartesia_admin_credential"),
         access_token=data.get("access_token"),
+        owner_id=data.get("owner_id"),
+        user_id=data.get("user_id"),
     )
 
 
@@ -509,6 +521,8 @@ class OAuthStore:
         params: AuthorizationParams,
         cartesia_credential: str,
         cartesia_admin_credential: str | None = None,
+        completing_owner_id: str | None = None,
+        completing_user_id: str | None = None,
     ) -> AuthorizationCode:
         code = secrets.token_urlsafe(32)
         auth_code = AuthorizationCode(
@@ -533,6 +547,8 @@ class OAuthStore:
                 "cartesia_admin_credential": cartesia_admin_credential,
                 "client_id": client_id,
                 "scopes": list(params.scopes or []),
+                "owner_id": completing_owner_id,
+                "user_id": completing_user_id,
             },
             ttl_seconds=AUTH_CODE_TTL_SECONDS,
         )
@@ -560,6 +576,8 @@ class OAuthStore:
         scopes: list[str],
         cartesia_credential: str,
         cartesia_admin_credential: str | None,
+        owner_id: str | None = None,
+        user_id: str | None = None,
     ) -> OAuthToken:
         access_token = secrets.token_urlsafe(32)
         refresh_token = secrets.token_urlsafe(32)
@@ -575,6 +593,8 @@ class OAuthStore:
             expires_at=access_expires_at,
             cartesia_admin_credential=cartesia_admin_credential,
             refresh_token=refresh_token,
+            owner_id=owner_id,
+            user_id=user_id,
         )
         refresh = StoredMcpRefreshToken(
             token=refresh_token,
@@ -584,6 +604,8 @@ class OAuthStore:
             expires_at=refresh_expires_at,
             cartesia_admin_credential=cartesia_admin_credential,
             access_token=access_token,
+            owner_id=owner_id,
+            user_id=user_id,
         )
         self._backend.set_json(
             f"{_KEY_ACCESS}{access_token}",
@@ -621,6 +643,8 @@ class OAuthStore:
             scopes=list(creds.get("scopes") or authorization_code.scopes or []),
             cartesia_credential=creds["cartesia_credential"],
             cartesia_admin_credential=creds.get("cartesia_admin_credential"),
+            owner_id=creds.get("owner_id"),
+            user_id=creds.get("user_id"),
         )
 
     def resolve_mcp_access_token(self, token: str) -> StoredMcpAccessToken | None:
@@ -680,6 +704,8 @@ class OAuthStore:
             scopes=list(requested_scopes),
             cartesia_credential=stored.cartesia_credential,
             cartesia_admin_credential=stored.cartesia_admin_credential,
+            owner_id=stored.owner_id,
+            user_id=stored.user_id,
         )
 
     def revoke_token(self, token: str) -> None:

--- a/tests/test_mcp_request_log.py
+++ b/tests/test_mcp_request_log.py
@@ -1,0 +1,122 @@
+"""Tests for hosted /mcp request logging."""
+
+import logging
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from cartesia_mcp.mcp_request_log import (
+    McpRequestLogMiddleware,
+    jsonrpc_method_from_body,
+)
+from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
+from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+
+def _reset_store() -> None:
+    oauth_store.use_backend(MemoryBackend())
+    oauth_store.clear()
+
+
+async def _ok_mcp(_: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+def _client_app() -> TestClient:
+    app = Starlette(
+        routes=[
+            Route("/mcp", endpoint=_ok_mcp, methods=["GET", "POST"]),
+            Route("/health", endpoint=_ok_mcp, methods=["GET"]),
+        ]
+    )
+    app.add_middleware(McpRequestLogMiddleware)
+    return TestClient(app)
+
+
+def _mint_oauth_token() -> str:
+    client = OAuthClientInformationFull(
+        client_id="log-client",
+        client_secret=None,
+        redirect_uris=[AnyUrl("cursor://callback")],
+        client_name="Cursor",
+        token_endpoint_auth_method="none",
+    )
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        AuthorizationParams(
+            state="s",
+            scopes=["mcp"],
+            code_challenge="challenge",
+            redirect_uri=AnyUrl("cursor://callback"),
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        ),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_logged",
+        completing_user_id="user_logged",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = oauth_store.load_authorization_code(
+        client,
+        redirect.split("code=")[1].split("&")[0],
+    )
+    assert auth_code is not None
+    token = oauth_store.exchange_authorization_code(client, auth_code)
+    return token.access_token
+
+
+def test_jsonrpc_method_from_body_reads_initialize():
+    assert (
+        jsonrpc_method_from_body(b'{"jsonrpc":"2.0","method":"initialize","id":1}')
+        == "initialize"
+    )
+    assert jsonrpc_method_from_body(b'[{"method":"tools/list"}]') == "tools/list"
+    assert jsonrpc_method_from_body(b"not-json") is None
+    assert jsonrpc_method_from_body(b'{"params":{}}') is None
+
+
+def test_mcp_request_log_includes_owner_and_rpc(caplog):
+    _reset_store()
+    access = _mint_oauth_token()
+    client = _client_app()
+    with caplog.at_level(logging.INFO, logger="cartesia_mcp.mcp"):
+        response = client.post(
+            "/mcp",
+            headers={"authorization": f"Bearer {access}"},
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        )
+    assert response.status_code == 200
+    records = [r.getMessage() for r in caplog.records if "mcp request" in r.getMessage()]
+    assert records
+    message = records[-1]
+    assert "rpc=tools/list" in message
+    assert "owner_id=org_logged" in message
+    assert "user_id=user_logged" in message
+    assert "client_name=Cursor" in message
+    assert "auth=oauth" in message
+    assert access not in message
+    assert "sk_car_oauth_test_key" not in message
+
+
+def test_mcp_request_log_skips_health(caplog):
+    _reset_store()
+    client = _client_app()
+    with caplog.at_level(logging.INFO, logger="cartesia_mcp.mcp"):
+        assert client.get("/health").status_code == 200
+    assert not [r for r in caplog.records if "mcp request" in r.getMessage()]

--- a/tests/test_oauth_store.py
+++ b/tests/test_oauth_store.py
@@ -448,6 +448,8 @@ def test_redis_backend_json_roundtrip(monkeypatch):
         params=pending.params,
         cartesia_credential=pending.cartesia_credential or "",
         cartesia_admin_credential=pending.cartesia_admin_credential,
+        completing_owner_id=pending.completing_owner_id,
+        completing_user_id=pending.completing_user_id,
     )
     loaded_code = store.load_authorization_code(client, auth_code.code)
     assert loaded_code is not None
@@ -457,6 +459,8 @@ def test_redis_backend_json_roundtrip(monkeypatch):
     assert resolved is not None
     assert resolved.cartesia_credential == "sk_car_oauth_test_key"
     assert resolved.cartesia_admin_credential == "sk_car_admin_test.key"
+    assert resolved.owner_id == "org_test"
+    assert resolved.user_id == "user_test"
 
     with pytest.raises(ValueError, match="Authorization code not found"):
         store.exchange_authorization_code(client, loaded_code)
@@ -492,3 +496,45 @@ def test_revoke_token_removes_access_and_refresh():
     oauth_store.revoke_token(token.access_token)
     assert oauth_store.resolve_mcp_access_token(token.access_token) is None
     assert oauth_store.load_refresh_token(client, token.refresh_token or "") is None
+
+
+def test_resume_redirect_persists_owner_on_access_token():
+    _reset_store()
+    client = _client()
+    oauth_store.register_client(client)
+    session_id, connect_token = oauth_store.create_pending_session(
+        client.client_id,
+        _params(),
+    )
+    oauth_store.attach_credential(
+        session_id,
+        connect_token,
+        "sk_car_oauth_test_key",
+        completing_owner_id="org_logged",
+        completing_user_id="user_logged",
+    )
+    pending = oauth_store.pop_pending(session_id)
+    provider = CartesiaOAuthProvider(
+        playground_url="https://play.cartesia.ai",
+        mcp_server_url="https://mcp.cartesia.ai",
+    )
+    redirect = provider.build_resume_redirect(session_id, pending)
+    auth_code = oauth_store.load_authorization_code(
+        client,
+        redirect.split("code=")[1].split("&")[0],
+    )
+    assert auth_code is not None
+    token = oauth_store.exchange_authorization_code(client, auth_code)
+    resolved = oauth_store.resolve_mcp_access_token(token.access_token)
+    assert resolved is not None
+    assert resolved.owner_id == "org_logged"
+    assert resolved.user_id == "user_logged"
+    refreshed = oauth_store.exchange_refresh_token(
+        client,
+        oauth_store.load_refresh_token(client, token.refresh_token or ""),
+        ["mcp"],
+    )
+    resolved_refresh = oauth_store.resolve_mcp_access_token(refreshed.access_token)
+    assert resolved_refresh is not None
+    assert resolved_refresh.owner_id == "org_logged"
+    assert resolved_refresh.user_id == "user_logged"


### PR DESCRIPTION
Rebased onto `main` after https://github.com/cartesia-ai/cartesia-mcp/pull/80.

## Summary

Hosted `/mcp` logs previously had IP and user-agent only. OAuth complete already knew the Clerk org, but that id never made it onto the access token, so a reconnect storm could not be attributed.

Minted MCP tokens now carry org and user ids. Each `/mcp` request logs HTTP method, JSON-RPC method, owner id, user id, OAuth client name, and status — never the bearer or Cartesia API key.

## Changes

- Persist `owner_id` / `user_id` through auth-code credentials onto access and refresh tokens
- Log line: `mcp request method=… rpc=… owner_id=… user_id=… client_name=… auth=… status=…`
- API-key bearers log `auth=api_key` without an org id

## Test plan

- [x] `uv run pytest`
- [ ] After deploy, complete OAuth Connect and confirm Render logs include `owner_id=`
- [ ] Confirm logs do not contain `sk_car_` or the MCP bearer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends OAuth token persistence and adds middleware that reads POST bodies and resolves bearer tokens; logging is designed to omit credentials but touches the auth request path.
> 
> **Overview**
> Adds **request logging** for hosted `/mcp` so reconnect storms and traffic can be tied to a Clerk org/user instead of only IP and user-agent.
> 
> **OAuth minted tokens** now carry `owner_id` and `user_id` from Connect completion through auth-code credentials onto access and refresh tokens (including refresh rotation). `build_resume_redirect` passes those ids when issuing codes.
> 
> A new **`McpRequestLogMiddleware`** logs one line per `/mcp` request: HTTP method, JSON-RPC method (from POST body), owner/user ids, OAuth client name, auth mode (`oauth` vs `api_key`), and response status. Bearers and Cartesia API keys are not logged. Non-`/mcp` routes (e.g. `/health`) are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cff90e62d5b45932ef64920e2917ae0e760e6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->