### PR TITLE
fix: keep hosted Streamable HTTP sessions stateful

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -83,10 +83,16 @@ def hosted_streamable_http_kwargs() -> dict[str, Any]:
 
     ``host="0.0.0.0"`` keeps DNS-rebinding auto-protection off so public Host
     headers like mcp.cartesia.ai are accepted (v2 defaults host to 127.0.0.1).
+
+    Stateful sessions emit ``Mcp-Session-Id`` and keep GET /mcp SSE open.
+    Stateless mode never assigns a session id (logs ``Terminating session: None``)
+    and some Streamable HTTP clients reconnect in a tight initialize/list/SSE
+    loop. Hosted MCP is a single Render replica, so in-memory sessions are OK;
+    deploys drop them and clients reconnect once.
     """
     return {
         "streamable_http_path": "/mcp",
-        "stateless_http": True,
+        "stateless_http": False,
         "host": hosted_bind_host(),
     }
 

--- a/tests/test_hosted_mode.py
+++ b/tests/test_hosted_mode.py
@@ -40,5 +40,5 @@ def test_hosted_server_auth_urls(monkeypatch):
 def test_hosted_streamable_http_kwargs(monkeypatch):
     kwargs = hosted_streamable_http_kwargs()
     assert kwargs["streamable_http_path"] == "/mcp"
-    assert kwargs["stateless_http"] is True
+    assert kwargs["stateless_http"] is False
     assert kwargs["host"] == "0.0.0.0"


### PR DESCRIPTION
## Summary

Hosted MCP ran with `stateless_http=True`. The mcp Python SDK then never emits `Mcp-Session-Id`, creates a fresh transport per request, and logs `Terminating session: None` when GET `/mcp` SSE ends. Cursor-class Streamable HTTP clients often reconnect immediately, which matches the reconnect storm on mcp.cartesia.ai.

This switches hosted mode to stateful sessions. The service is a single Render replica, so in-memory session state is enough; deploys drop sessions and clients reconnect once. Rate limiting on `/mcp` remains the safety net for a rude client.

## Changes

- `hosted_streamable_http_kwargs()` sets `stateless_http` to `False`
- Comment why hosted stays single-replica / in-memory

## Test plan

- [x] `uv run pytest`
- [ ] After deploy, connect Cursor to `https://mcp.cartesia.ai/mcp` once
- [ ] Confirm responses include `Mcp-Session-Id`
- [ ] Confirm GET `/mcp` SSE stays open instead of initialize/list/SSE looping
- [ ] Confirm logs no longer spam `Terminating session: None`