### PR TITLE
fix: cap hosted MCP sessions and tighten initialize rate limits

### DIFF
--- a/cartesia_mcp/hosted.py
+++ b/cartesia_mcp/hosted.py
@@ -236,9 +236,18 @@ def run_hosted(mcp: MCPServer) -> None:
 
     from cartesia_mcp.mcp_rate_limit import McpRateLimitMiddleware
     from cartesia_mcp.mcp_request_log import McpRequestLogMiddleware
+    from cartesia_mcp.mcp_session_guard import (
+        McpSessionCapMiddleware,
+        configure_hosted_session_manager,
+    )
     from cartesia_mcp.register_rate_limit import RegisterRateLimitMiddleware
 
     app = mcp.streamable_http_app(**hosted_streamable_http_kwargs())
+    configure_hosted_session_manager(mcp.session_manager)
+    app.add_middleware(
+        McpSessionCapMiddleware,
+        session_manager=mcp.session_manager,
+    )
     app.add_middleware(McpRateLimitMiddleware)
     app.add_middleware(McpRequestLogMiddleware)
     app.add_middleware(RegisterRateLimitMiddleware)

--- a/cartesia_mcp/mcp_http.py
+++ b/cartesia_mcp/mcp_http.py
@@ -1,0 +1,51 @@
+"""Shared helpers for hosted Streamable HTTP /mcp middleware."""
+
+from __future__ import annotations
+
+import json
+
+from starlette.requests import Request
+
+from cartesia_mcp.register_rate_limit import client_ip
+
+_MAX_RPC_METHOD_LEN = 64
+
+
+def is_mcp_path(path: str) -> bool:
+    return path.rstrip("/") == "/mcp"
+
+
+def bearer_token(request: Request) -> str | None:
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:].strip()
+    return token or None
+
+
+def jsonrpc_method_from_body(body: bytes) -> str | None:
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    method: object = None
+    if isinstance(payload, dict):
+        method = payload.get("method")
+    elif isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        method = payload[0].get("method")
+    if not isinstance(method, str) or not method or len(method) > _MAX_RPC_METHOD_LEN:
+        return None
+    return method
+
+
+def mcp_rate_limit_bucket(request: Request) -> str:
+    """Prefer a hashed bearer so shared egress IPs do not share one bucket."""
+    import hashlib
+
+    token = bearer_token(request)
+    if token is not None:
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+        return f"tok:{digest}"
+    return f"ip:{client_ip(request)}"

--- a/cartesia_mcp/mcp_rate_limit.py
+++ b/cartesia_mcp/mcp_rate_limit.py
@@ -2,40 +2,42 @@
 
 from __future__ import annotations
 
-import hashlib
-
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
+from cartesia_mcp.mcp_http import (
+    is_mcp_path,
+    jsonrpc_method_from_body,
+    mcp_rate_limit_bucket,
+)
 from cartesia_mcp.oauth_store import oauth_store
 from cartesia_mcp.register_rate_limit import client_ip
 
-# Burst of ~60 in 10s covers initialize + tools/list + SSE; tens of rps reconnects trip it.
-MCP_RATE_LIMIT = 60
+# General /mcp burst; reconnect storms still need initialize-specific limits below.
+MCP_RATE_LIMIT = 30
 MCP_RATE_WINDOW_SECONDS = 10
 
+# Secondary IP bucket so one egress cannot mint sessions across many API keys.
+MCP_IP_RATE_LIMIT = 120
+MCP_IP_RATE_WINDOW_SECONDS = 10
 
-def is_mcp_path(path: str) -> bool:
-    return path.rstrip("/") == "/mcp"
-
-
-def bearer_token(request: Request) -> str | None:
-    auth = request.headers.get("authorization", "")
-    if not auth.lower().startswith("bearer "):
-        return None
-    token = auth[7:].strip()
-    return token or None
+# New session handshakes are expensive; keep well below general /mcp throughput.
+MCP_INITIALIZE_RATE_LIMIT = 5
+MCP_INITIALIZE_RATE_WINDOW_SECONDS = 60
+MCP_INITIALIZE_IP_RATE_LIMIT = 15
 
 
-def mcp_rate_limit_bucket(request: Request) -> str:
-    """Prefer a hashed bearer so shared egress IPs do not share one bucket."""
-    token = bearer_token(request)
-    if token is not None:
-        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
-        return f"tok:{digest}"
-    return f"ip:{client_ip(request)}"
+def _too_many_requests(retry_after: int, description: str) -> JSONResponse:
+    return JSONResponse(
+        {
+            "error": "too_many_requests",
+            "error_description": description,
+        },
+        status_code=429,
+        headers={"Retry-After": str(retry_after)},
+    )
 
 
 class McpRateLimitMiddleware(BaseHTTPMiddleware):
@@ -43,19 +45,56 @@ class McpRateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        if request.method in ("GET", "POST", "DELETE") and is_mcp_path(request.url.path):
-            bucket = mcp_rate_limit_bucket(request)
-            count = oauth_store.increment_mcp_attempts(
-                bucket,
-                window_seconds=MCP_RATE_WINDOW_SECONDS,
+        if request.method not in ("GET", "POST", "DELETE") or not is_mcp_path(
+            request.url.path
+        ):
+            return await call_next(request)
+
+        ip = client_ip(request)
+        bucket = mcp_rate_limit_bucket(request)
+
+        if bucket.startswith("tok:"):
+            ip_count = oauth_store.increment_mcp_attempts(
+                f"allip:{ip}",
+                window_seconds=MCP_IP_RATE_WINDOW_SECONDS,
             )
-            if count > MCP_RATE_LIMIT:
-                return JSONResponse(
-                    {
-                        "error": "too_many_requests",
-                        "error_description": "MCP request rate limit exceeded",
-                    },
-                    status_code=429,
-                    headers={"Retry-After": str(MCP_RATE_WINDOW_SECONDS)},
+            if ip_count > MCP_IP_RATE_LIMIT:
+                return _too_many_requests(
+                    MCP_IP_RATE_WINDOW_SECONDS,
+                    "MCP request rate limit exceeded for this IP",
                 )
+
+        count = oauth_store.increment_mcp_attempts(
+            bucket,
+            window_seconds=MCP_RATE_WINDOW_SECONDS,
+        )
+        if count > MCP_RATE_LIMIT:
+            return _too_many_requests(
+                MCP_RATE_WINDOW_SECONDS,
+                "MCP request rate limit exceeded",
+            )
+
+        if request.method == "POST":
+            rpc_method = jsonrpc_method_from_body(await request.body())
+            if rpc_method == "initialize":
+                init_count = oauth_store.increment_mcp_attempts(
+                    f"init:{bucket}",
+                    window_seconds=MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+                )
+                if init_count > MCP_INITIALIZE_RATE_LIMIT:
+                    return _too_many_requests(
+                        MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+                        "MCP initialize rate limit exceeded",
+                    )
+
+                ip_init_count = oauth_store.increment_mcp_attempts(
+                    f"init:ip:{ip}",
+                    window_seconds=MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+                )
+                if ip_init_count > MCP_INITIALIZE_IP_RATE_LIMIT:
+                    return _too_many_requests(
+                        MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+                        "MCP initialize rate limit exceeded for this IP",
+                    )
+
         return await call_next(request)

--- a/cartesia_mcp/mcp_rate_limit.py
+++ b/cartesia_mcp/mcp_rate_limit.py
@@ -9,11 +9,11 @@ from starlette.types import ASGIApp
 
 from cartesia_mcp.mcp_http import (
     is_mcp_path,
-    jsonrpc_method_from_body,
     mcp_rate_limit_bucket,
 )
 from cartesia_mcp.oauth_store import oauth_store
 from cartesia_mcp.register_rate_limit import client_ip
+from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
 
 # General /mcp burst; reconnect storms still need initialize-specific limits below.
 MCP_RATE_LIMIT = 30
@@ -74,27 +74,26 @@ class McpRateLimitMiddleware(BaseHTTPMiddleware):
                 "MCP request rate limit exceeded",
             )
 
-        if request.method == "POST":
-            rpc_method = jsonrpc_method_from_body(await request.body())
-            if rpc_method == "initialize":
-                init_count = oauth_store.increment_mcp_attempts(
-                    f"init:{bucket}",
-                    window_seconds=MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+        if request.method == "POST" and request.headers.get(MCP_SESSION_ID_HEADER) is None:
+            init_count = oauth_store.increment_mcp_attempts(
+                f"init:{bucket}",
+                window_seconds=MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+            )
+            if init_count > MCP_INITIALIZE_RATE_LIMIT:
+                return _too_many_requests(
+                    MCP_INITIALIZE_RATE_WINDOW_SECONDS,
+                    "MCP session creation rate limit exceeded",
                 )
-                if init_count > MCP_INITIALIZE_RATE_LIMIT:
-                    return _too_many_requests(
-                        MCP_INITIALIZE_RATE_WINDOW_SECONDS,
-                        "MCP initialize rate limit exceeded",
-                    )
 
+            if bucket.startswith("tok:"):
                 ip_init_count = oauth_store.increment_mcp_attempts(
-                    f"init:ip:{ip}",
+                    f"initallip:{ip}",
                     window_seconds=MCP_INITIALIZE_RATE_WINDOW_SECONDS,
                 )
                 if ip_init_count > MCP_INITIALIZE_IP_RATE_LIMIT:
                     return _too_many_requests(
                         MCP_INITIALIZE_RATE_WINDOW_SECONDS,
-                        "MCP initialize rate limit exceeded for this IP",
+                        "MCP session creation rate limit exceeded for this IP",
                     )
 
         return await call_next(request)

--- a/cartesia_mcp/mcp_request_log.py
+++ b/cartesia_mcp/mcp_request_log.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 
@@ -12,12 +11,10 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 
 from cartesia_mcp.credentials import looks_like_cartesia_api_key
-from cartesia_mcp.mcp_rate_limit import bearer_token, is_mcp_path
+from cartesia_mcp.mcp_http import bearer_token, is_mcp_path, jsonrpc_method_from_body
 from cartesia_mcp.oauth_store import oauth_store
 
 logger = logging.getLogger("cartesia_mcp.mcp")
-
-_MAX_RPC_METHOD_LEN = 64
 
 
 @dataclass(frozen=True)
@@ -26,23 +23,6 @@ class McpRequestIdentity:
     user_id: str | None = None
     client_name: str | None = None
     auth: str | None = None
-
-
-def jsonrpc_method_from_body(body: bytes) -> str | None:
-    if not body:
-        return None
-    try:
-        payload = json.loads(body)
-    except json.JSONDecodeError:
-        return None
-    method: object = None
-    if isinstance(payload, dict):
-        method = payload.get("method")
-    elif isinstance(payload, list) and payload and isinstance(payload[0], dict):
-        method = payload[0].get("method")
-    if not isinstance(method, str) or not method or len(method) > _MAX_RPC_METHOD_LEN:
-        return None
-    return method
 
 
 def mcp_request_identity(request: Request) -> McpRequestIdentity:

--- a/cartesia_mcp/mcp_session_guard.py
+++ b/cartesia_mcp/mcp_session_guard.py
@@ -1,0 +1,57 @@
+"""Cap concurrent Streamable HTTP MCP sessions on the hosted server."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+from cartesia_mcp.mcp_http import is_mcp_path
+
+# Enough for normal OAuth clients; blocks reconnect storms from unbounded growth.
+MCP_MAX_CONCURRENT_SESSIONS = 256
+
+# Reclaim idle SSE sessions; SDK default is None (no timeout).
+MCP_SESSION_IDLE_TIMEOUT_SECONDS = 300
+
+
+def active_session_count(session_manager: StreamableHTTPSessionManager) -> int:
+    return len(session_manager._server_instances)
+
+
+def configure_hosted_session_manager(
+    session_manager: StreamableHTTPSessionManager,
+) -> None:
+    session_manager.session_idle_timeout = MCP_SESSION_IDLE_TIMEOUT_SECONDS
+
+
+class McpSessionCapMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        session_manager: StreamableHTTPSessionManager,
+    ) -> None:
+        super().__init__(app)
+        self._session_manager = session_manager
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if (
+            request.method == "POST"
+            and is_mcp_path(request.url.path)
+            and request.headers.get(MCP_SESSION_ID_HEADER) is None
+            and active_session_count(self._session_manager) >= MCP_MAX_CONCURRENT_SESSIONS
+        ):
+            return JSONResponse(
+                {
+                    "error": "service_unavailable",
+                    "error_description": "Too many active MCP sessions",
+                },
+                status_code=503,
+                headers={"Retry-After": "30"},
+            )
+        return await call_next(request)

--- a/tests/test_mcp_rate_limit.py
+++ b/tests/test_mcp_rate_limit.py
@@ -6,10 +6,13 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from cartesia_mcp.mcp_http import mcp_rate_limit_bucket
 from cartesia_mcp.mcp_rate_limit import (
+    MCP_INITIALIZE_IP_RATE_LIMIT,
+    MCP_INITIALIZE_RATE_LIMIT,
+    MCP_IP_RATE_LIMIT,
     MCP_RATE_LIMIT,
     McpRateLimitMiddleware,
-    mcp_rate_limit_bucket,
 )
 from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
 
@@ -96,6 +99,76 @@ def test_mcp_rate_limit_blocks_over_cap():
         json={},
     )
     assert other.status_code == 200
+
+
+def test_mcp_rate_limit_ip_bucket_applies_with_bearer():
+    _reset_store()
+    client = _client()
+    shared_ip = "198.51.100.44"
+    for i in range(MCP_IP_RATE_LIMIT):
+        response = client.post(
+            "/mcp",
+            headers={
+                "authorization": f"Bearer tok-{i}",
+                "x-forwarded-for": shared_ip,
+            },
+            json={},
+        )
+        assert response.status_code == 200
+
+    blocked = client.post(
+        "/mcp",
+        headers={
+            "authorization": "Bearer tok-overflow",
+            "x-forwarded-for": shared_ip,
+        },
+        json={},
+    )
+    assert blocked.status_code == 429
+    assert "IP" in blocked.json()["error_description"]
+
+
+def test_mcp_initialize_rate_limit_blocks_handshake_storm():
+    _reset_store()
+    client = _client()
+    headers = {
+        "authorization": "Bearer init-storm",
+        "x-forwarded-for": "198.51.100.55",
+    }
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+    for _ in range(MCP_INITIALIZE_RATE_LIMIT):
+        assert client.post("/mcp", headers=headers, json=payload).status_code == 200
+
+    blocked = client.post("/mcp", headers=headers, json=payload)
+    assert blocked.status_code == 429
+    assert "initialize" in blocked.json()["error_description"]
+
+
+def test_mcp_initialize_ip_rate_limit_blocks_shared_egress():
+    _reset_store()
+    client = _client()
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+    for i in range(MCP_INITIALIZE_IP_RATE_LIMIT):
+        response = client.post(
+            "/mcp",
+            headers={
+                "authorization": f"Bearer init-key-{i}",
+                "x-forwarded-for": "198.51.100.66",
+            },
+            json=payload,
+        )
+        assert response.status_code == 200
+
+    blocked = client.post(
+        "/mcp",
+        headers={
+            "authorization": "Bearer init-key-overflow",
+            "x-forwarded-for": "198.51.100.66",
+        },
+        json=payload,
+    )
+    assert blocked.status_code == 429
+    assert "IP" in blocked.json()["error_description"]
 
 
 def test_mcp_rate_limit_unauthenticated_keys_by_ip():

--- a/tests/test_mcp_rate_limit.py
+++ b/tests/test_mcp_rate_limit.py
@@ -37,6 +37,10 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
+def _existing_session_headers(**extra: str) -> dict[str, str]:
+    return {"mcp-session-id": "existing-session", **extra}
+
+
 def test_mcp_rate_limit_bucket_prefers_bearer_hash():
     scope = {
         "type": "http",
@@ -66,11 +70,11 @@ def test_mcp_rate_limit_allows_under_cap():
     for _ in range(MCP_RATE_LIMIT):
         response = client.post(
             "/mcp",
-            headers={
-                "authorization": "Bearer tok-a",
-                "x-forwarded-for": "198.51.100.2",
-            },
-            json={},
+            headers=_existing_session_headers(
+                authorization="Bearer tok-a",
+                **{"x-forwarded-for": "198.51.100.2"},
+            ),
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
         )
         assert response.status_code == 200
 
@@ -78,25 +82,36 @@ def test_mcp_rate_limit_allows_under_cap():
 def test_mcp_rate_limit_blocks_over_cap():
     _reset_store()
     client = _client()
-    headers = {
-        "authorization": "Bearer tok-b",
-        "x-forwarded-for": "198.51.100.3",
-    }
+    headers = _existing_session_headers(
+        authorization="Bearer tok-b",
+        **{"x-forwarded-for": "198.51.100.3"},
+    )
     for _ in range(MCP_RATE_LIMIT):
-        assert client.post("/mcp", headers=headers, json={}).status_code == 200
+        assert (
+            client.post(
+                "/mcp",
+                headers=headers,
+                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+            ).status_code
+            == 200
+        )
 
-    blocked = client.post("/mcp", headers=headers, json={})
+    blocked = client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+    )
     assert blocked.status_code == 429
     assert blocked.json()["error"] == "too_many_requests"
     assert blocked.headers["retry-after"] == "10"
 
     other = client.post(
         "/mcp",
-        headers={
-            "authorization": "Bearer tok-c",
-            "x-forwarded-for": "198.51.100.3",
-        },
-        json={},
+        headers=_existing_session_headers(
+            authorization="Bearer tok-c",
+            **{"x-forwarded-for": "198.51.100.3"},
+        ),
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
     )
     assert other.status_code == 200
 
@@ -108,21 +123,21 @@ def test_mcp_rate_limit_ip_bucket_applies_with_bearer():
     for i in range(MCP_IP_RATE_LIMIT):
         response = client.post(
             "/mcp",
-            headers={
-                "authorization": f"Bearer tok-{i}",
-                "x-forwarded-for": shared_ip,
-            },
-            json={},
+            headers=_existing_session_headers(
+                authorization=f"Bearer tok-{i}",
+                **{"x-forwarded-for": shared_ip},
+            ),
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
         )
         assert response.status_code == 200
 
     blocked = client.post(
         "/mcp",
-        headers={
-            "authorization": "Bearer tok-overflow",
-            "x-forwarded-for": shared_ip,
-        },
-        json={},
+        headers=_existing_session_headers(
+            authorization="Bearer tok-overflow",
+            **{"x-forwarded-for": shared_ip},
+        ),
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
     )
     assert blocked.status_code == 429
     assert "IP" in blocked.json()["error_description"]
@@ -141,7 +156,48 @@ def test_mcp_initialize_rate_limit_blocks_handshake_storm():
 
     blocked = client.post("/mcp", headers=headers, json=payload)
     assert blocked.status_code == 429
-    assert "initialize" in blocked.json()["error_description"]
+    assert "session creation" in blocked.json()["error_description"]
+
+
+def test_mcp_session_creation_limit_applies_without_initialize_method():
+    _reset_store()
+    client = _client()
+    headers = {
+        "authorization": "Bearer mint-storm",
+        "x-forwarded-for": "198.51.100.77",
+    }
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    for _ in range(MCP_INITIALIZE_RATE_LIMIT):
+        assert client.post("/mcp", headers=headers, json=payload).status_code == 200
+
+    blocked = client.post("/mcp", headers=headers, json=payload)
+    assert blocked.status_code == 429
+    assert "session creation" in blocked.json()["error_description"]
+
+
+def test_mcp_session_creation_limit_skips_existing_session():
+    _reset_store()
+    client = _client()
+    headers = _existing_session_headers(
+        authorization="Bearer mint-storm",
+        **{"x-forwarded-for": "198.51.100.78"},
+    )
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    for _ in range(MCP_INITIALIZE_RATE_LIMIT + 3):
+        assert client.post("/mcp", headers=headers, json=payload).status_code == 200
+
+
+def test_mcp_unauthenticated_session_creation_uses_single_bucket():
+    _reset_store()
+    client = _client()
+    headers = {"x-forwarded-for": "198.51.100.88"}
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+    for _ in range(MCP_INITIALIZE_RATE_LIMIT):
+        assert client.post("/mcp", headers=headers, json=payload).status_code == 200
+
+    blocked = client.post("/mcp", headers=headers, json=payload)
+    assert blocked.status_code == 429
+    assert "session creation" in blocked.json()["error_description"]
 
 
 def test_mcp_initialize_ip_rate_limit_blocks_shared_egress():

--- a/tests/test_mcp_request_log.py
+++ b/tests/test_mcp_request_log.py
@@ -8,10 +8,8 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from cartesia_mcp.mcp_request_log import (
-    McpRequestLogMiddleware,
-    jsonrpc_method_from_body,
-)
+from cartesia_mcp.mcp_http import jsonrpc_method_from_body
+from cartesia_mcp.mcp_request_log import McpRequestLogMiddleware
 from cartesia_mcp.oauth_provider import CartesiaOAuthProvider
 from cartesia_mcp.oauth_store import MemoryBackend, oauth_store
 from mcp.server.auth.provider import AuthorizationParams

--- a/tests/test_mcp_session_guard.py
+++ b/tests/test_mcp_session_guard.py
@@ -1,0 +1,68 @@
+"""Tests for hosted MCP session cap middleware."""
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from cartesia_mcp.mcp_session_guard import (
+    MCP_MAX_CONCURRENT_SESSIONS,
+    McpSessionCapMiddleware,
+    configure_hosted_session_manager,
+)
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+
+class _FakeServer:
+    pass
+
+
+async def _ok_mcp(_: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+def _session_manager(*, active: int) -> StreamableHTTPSessionManager:
+    manager = StreamableHTTPSessionManager(_FakeServer())
+    manager._server_instances = {f"s{i}": object() for i in range(active)}
+    return manager
+
+
+def _client(session_manager: StreamableHTTPSessionManager) -> TestClient:
+    app = Starlette(routes=[Route("/mcp", endpoint=_ok_mcp, methods=["POST"])])
+    app.add_middleware(
+        McpSessionCapMiddleware,
+        session_manager=session_manager,
+    )
+    return TestClient(app)
+
+
+def test_configure_hosted_session_manager_sets_idle_timeout():
+    manager = _session_manager(active=0)
+    assert manager.session_idle_timeout is None
+    configure_hosted_session_manager(manager)
+    assert manager.session_idle_timeout == 300
+
+
+def test_session_cap_allows_new_session_under_limit():
+    client = _client(_session_manager(active=MCP_MAX_CONCURRENT_SESSIONS - 1))
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "method": "initialize"})
+    assert response.status_code == 200
+
+
+def test_session_cap_blocks_new_session_at_limit():
+    client = _client(_session_manager(active=MCP_MAX_CONCURRENT_SESSIONS))
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "method": "initialize"})
+    assert response.status_code == 503
+    assert response.json()["error"] == "service_unavailable"
+    assert response.headers["retry-after"] == "30"
+
+
+def test_session_cap_allows_existing_session_when_at_limit():
+    client = _client(_session_manager(active=MCP_MAX_CONCURRENT_SESSIONS))
+    response = client.post(
+        "/mcp",
+        headers={"mcp-session-id": "existing-session"},
+        json={"jsonrpc": "2.0", "method": "tools/list"},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Hosted Streamable HTTP MCP was still vulnerable to reconnect storms: each allowed `initialize` created an in-memory session with no cap or idle expiry, and the `/mcp` rate limit was too loose to stop session growth before OOM.

## Changes

- Cap concurrent stateful sessions at 256; reject new handshakes with 503 when full.
- Set SDK session idle timeout to 5 minutes after app startup.
- Tighten general `/mcp` limits (30/10s per credential) and add a secondary IP bucket for authenticated traffic.
- Add initialize-specific limits (5/min per credential, 15/min per IP).
- Extract shared `/mcp` HTTP helpers into `mcp_http.py` to avoid middleware import cycles.

## Test plan

- [x] `uv run pytest tests/test_mcp_rate_limit.py tests/test_mcp_session_guard.py tests/test_mcp_request_log.py tests/test_hosted_mode.py`

Made with [Cursor](https://cursor.com)